### PR TITLE
Added configurable MapTips, fixed problem with Legend and TOC being in o...

### DIFF
--- a/viewer/css/main.css
+++ b/viewer/css/main.css
@@ -45,16 +45,26 @@ body, html {
     top: 18px;
 }
 
+/*lcs - Map Tips - changed top from 27 to 10, position from relative to absolute*/
 .header .headerLinks {
     float: right;
     color: #FFFFFF;
-    position: relative;
-    top: 27px;
+    position: absolute;
+    top: 10px;
     right: 10px;
 }
 
 .header .headerLinks a {
     color: #FFFFFF;
+}
+
+/*lcs - Map Tips*/
+.header .mapTips  {
+    color: #FFFFFF;
+    float: right;
+    right: 10px;
+    position: absolute;
+    top:40px;
 }
 
 #borderContainer {

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -27,6 +27,9 @@
                     <a id="helpA" href="#">Help</a>
                 </div>
             </div>
+            <div id="mapTips" class="mapTips"><!-- lcs - Map Tips" -->
+                <input id='chkMapTips' type="checkbox" checked>  Map Tips</input>
+            </div>
         </div>
         <div id="sidebarCollapseButton" class="sidebarCollapseButton close" style="display:none;">
         </div>

--- a/viewer/js/viewer/config.js
+++ b/viewer/js/viewer/config.js
@@ -1,6 +1,7 @@
 define([
-	'esri/InfoTemplate'
-], function(InfoTemplate) {
+	//lcs - MapTips - added SimpleFillSymbol, SimpleLineSymbol, SimpleMarkerSymbol, and Color
+	'esri/InfoTemplate', 'esri/symbols/SimpleFillSymbol', 'esri/symbols/SimpleLineSymbol', 'esri/symbols/SimpleMarkerSymbol', 'dojo/_base/Color'
+], function(InfoTemplate, SimpleFillSymbol, SimpleLineSymbol, SimpleMarkerSymbol, Color) {
 	return {
 		// url to your proxy page, must be on same machine hosting you app. See proxy folder for readme.
 		proxy: {
@@ -37,6 +38,11 @@ define([
 			type: "feature",
 			url: "http://services1.arcgis.com/g2TonOxuRkIqSOFx/arcgis/rest/services/MeetUpHomeTowns/FeatureServer/0",
 			title: "STLJS Meetup Home Towns",
+			//lcs - MapTips BEGIN
+			highlightSymbol: new SimpleMarkerSymbol(SimpleMarkerSymbol.STYLE_CIRCLE, 14, new SimpleLineSymbol(SimpleLineSymbol.STYLE_SOLID, new Color([255,255,0]), 3), new Color([255,255,0,0])),
+			mapTip: "Location: <b>${Location}</b>",
+			mapTipNoValue: "[No Value]",
+			//lcs - MapTips END
 			options: {
 				id: "meetupHometowns",
 				opacity: 1.0,


### PR DESCRIPTION
...pposite order

A MapTip is a tooltip that appears when you hover over a feature.  The
content of the MapTip is configurable.  The feature is highlighted by a
configurable symbol (SimpleMarkerSymbol, SimpleLineSymbol, or
SimpleFillSymbol).  If any of the attributes defined in the MapTip have
no value, then they will display a configurable string.  There is a
checkbox in the header for turning MapTips on and off.

The Legend and TOC had their layers in the opposite order.  The Legend
was correct.  I fixed the TOC.
