### PR TITLE
Sort widgets by position before initializing

### DIFF
--- a/viewer/js/viewer/Controller.js
+++ b/viewer/js/viewer/Controller.js
@@ -26,6 +26,107 @@ define([
     'gis/dijit/Identify',
     'dojo/aspect'
 ], function(Map, Geocoder, FeatureLayer, osm, dom, domConstruct, Style, domClass, on, parser, array, BorderContainer, ContentPane, TitlePane, win, lang, Growler, GeoLocation, Help, Basemaps, mapOverlay, config, IdentityManager, GeometryService, Identify, aspect) {
+
+    var widgetInitializers = {
+        scalebar: function (widgetConfig) {
+            require(['esri/dijit/Scalebar'], lang.hitch(this, function (Scalebar) {
+                this.scalebar = new Scalebar({
+                    map: this.map,
+                    attachTo: config.widgets.scalebar.options.attachTo,
+                    scalebarStyle: config.widgets.scalebar.options.scalebarStyle,
+                    scalebarUnit: config.widgets.scalebar.options.scalebarUnit
+                });
+            }));
+        },
+        legend: function (widgetConfig, position) {
+            var legendTP = this._createTitlePane(widgetConfig.title, position, widgetConfig.open);
+            require(['esri/dijit/Legend'], lang.hitch(this, function (Legend) {
+                this.legend = new Legend({
+                    map: this.map,
+                    layerInfos: this.legendLayerInfos
+                }, domConstruct.create("div")).placeAt(legendTP.containerNode);
+            }));
+        },
+        TOC: function (widgetConfig, position) {
+            var TOCTP = this._createTitlePane(widgetConfig.title, position, widgetConfig.open);
+            require(['gis/dijit/TOC'], lang.hitch(this, function (TOC) {
+                this.toc = new TOC({
+                    map: this.map,
+                    layerInfos: this.legendLayerInfos
+                }, domConstruct.create("div")).placeAt(TOCTP.containerNode);
+                this.toc.startup();
+            }));
+        },
+        bookmarks: function (widgetConfig, position) {
+            var bookmarksTP = this._createTitlePane(widgetConfig.title, position, widgetConfig.open);
+            require(['gis/dijit/Bookmarks'], lang.hitch(this, function (Bookmarks) {
+                this.bookmarks = new Bookmarks({
+                    map: this.map,
+                    editable: true
+                }, domConstruct.create("div")).placeAt(bookmarksTP.containerNode);
+                this.bookmarks.startup();
+            }));
+        },
+        draw: function (widgetConfig, position) {
+            var drawTP = this._createTitlePane(widgetConfig.title, position, widgetConfig.open);
+            require(['gis/dijit/Draw'], lang.hitch(this, function (Draw) {
+                this.drawWidget = new Draw({
+                    map: this.map
+                }, domConstruct.create("div")).placeAt(drawTP.containerNode);
+                this.drawWidget.startup();
+            }));
+        },
+        measure: function (widgetConfig, position) {
+            var measureTP = this._createTitlePane(widgetConfig.title, position, widgetConfig.open);
+            require(['esri/dijit/Measurement'], lang.hitch(this, function (Measurement) {
+                this.measure = new Measurement({
+                    map: this.map,
+                    defaultAreaUnit: widgetConfig.defaultAreaUnit,
+                    defaultLengthUnit: widgetConfig.defaultLengthUnit
+                }, domConstruct.create("div")).placeAt(measureTP.containerNode);
+                this.measure.startup();
+            }));
+        },
+        directions: function (widgetConfig, position) {
+            var directionsTP = this._createTitlePane(widgetConfig.title, position, widgetConfig.open);
+            require(['gis/dijit/Directions'], lang.hitch(this, function (Directions) {
+                this.directionsWidget = new Directions({
+                    map: this.map,
+                    options: widgetConfig.options,
+                    titlePane: directionsTP
+                }, domConstruct.create("div")).placeAt(directionsTP.containerNode);
+                this.directionsWidget.startup();
+            }));
+        },
+        print: function (widgetConfig, position) {
+            var printTP = this._createTitlePane(widgetConfig.title, position, widgetConfig.open);
+            require(['gis/dijit/Print'], lang.hitch(this, function (Print) {
+                this.printWidget = new Print({
+                    map: this.map,
+                    printTaskURL: widgetConfig.serviceURL,
+                    authorText: widgetConfig.authorText,
+                    copyrightText: widgetConfig.copyrightText,
+                    defaultTitle: widgetConfig.defaultTitle,
+                    defaultFormat: widgetConfig.defaultFormat,
+                    defaultLayout: widgetConfig.defaultLayout
+                }, domConstruct.create("div")).placeAt(printTP.containerNode);
+                this.printWidget.startup();
+            }));
+        },
+        editor: function (widgetConfig, position) {
+            var editorTP = this._createTitlePane(widgetConfig.title, position, widgetConfig.open);
+            require(['gis/dijit/Editor'], lang.hitch(this, function (Editor) {
+                this.editor = new Editor({
+                    map: this.map,
+                    layerInfos: this.editorLayerInfos,
+                    settings: widgetConfig.settings,
+                    titlePane: editorTP
+                }, domConstruct.create("div")).placeAt(editorTP.containerNode);
+                this.editor.startup();
+            }));
+        }        
+    };
+
     return {
         config: config,
         legendLayerInfos: [],
@@ -147,118 +248,20 @@ define([
                 mapClickMode: this.mapClickMode
             });
 
-            if (config.widgets.scalebar && config.widgets.scalebar.include) {
-                require(['esri/dijit/Scalebar'], lang.hitch(this, function(Scalebar) {
-                    this.scalebar = new Scalebar({
-                        map: this.map,
-                        attachTo: config.widgets.scalebar.options.attachTo,
-                        scalebarStyle: config.widgets.scalebar.options.scalebarStyle,
-                        scalebarUnit: config.widgets.scalebar.options.scalebarUnit
-                    });
-                }));
-            }
+            var widgets = [];
+            for (var key in config.widgets) {
+                var widget = lang.clone(config.widgets[key]);
+                if (widget.include) {
+                    widget.position = 'undefined' !== typeof widget.position ? widget.position : 10000;
 
-            if (config.widgets.legend && config.widgets.legend.include) {
-                var legendTP = this._createTitlePane(config.widgets.legend.title, config.widgets.legend.position, config.widgets.legend.open);
-                require(['esri/dijit/Legend'], lang.hitch(this, function(Legend) {
-                    this.legend = new Legend({
-                        map: this.map,
-                        layerInfos: this.legendLayerInfos
-                    }, domConstruct.create("div")).placeAt(legendTP.containerNode);
-                }));
+                    widgets.push({ 'key': key, 'config': widget });
+                }
             }
+            widgets.sort(function (a, b) { return a.config.position - b.config.position; });
 
-            if (config.widgets.TOC && config.widgets.TOC.include) {
-                var TOCTP = this._createTitlePane(config.widgets.TOC.title, config.widgets.TOC.position, config.widgets.TOC.open);
-                require(['gis/dijit/TOC'], lang.hitch(this, function(TOC) {
-                    this.toc = new TOC({
-                        map: this.map,
-                        layerInfos: this.tocLayerInfos
-                    }, domConstruct.create("div")).placeAt(TOCTP.containerNode);
-                    this.toc.startup();
-                }));
-            }
-
-            if (config.widgets.bookmarks && config.widgets.bookmarks.include) {
-                var bookmarksTP = this._createTitlePane(config.widgets.bookmarks.title, config.widgets.bookmarks.position, config.widgets.bookmarks.open);
-                require(['gis/dijit/Bookmarks'], lang.hitch(this, function(Bookmarks) {
-                    this.bookmarks = new Bookmarks({
-                        map: this.map,
-                        editable: true
-                    }, domConstruct.create("div")).placeAt(bookmarksTP.containerNode);
-                    this.bookmarks.startup();
-                }));
-            }
-
-            if (config.widgets.draw && config.widgets.draw.include) {
-                var drawTP = this._createTitlePane(config.widgets.draw.title, config.widgets.draw.position, config.widgets.draw.open);
-                require(['gis/dijit/Draw'], lang.hitch(this, function(Draw) {
-                    this.drawWidget = new Draw({
-                        map: this.map,
-                        mapClickMode: this.mapClickMode
-                    }, domConstruct.create("div")).placeAt(drawTP.containerNode);
-                    this.drawWidget.startup();
-                }));
-            }
-
-            if (config.widgets.measure && config.widgets.measure.include) {
-                var measureTP = this._createTitlePane(config.widgets.measure.title, config.widgets.measure.position, config.widgets.measure.open);
-                require(['esri/dijit/Measurement'], lang.hitch(this, function(Measurement) {
-                    this.measure = new Measurement({
-                        map: this.map,
-                        mapClickMode: this.mapClickMode,
-                        defaultAreaUnit: config.widgets.measure.defaultAreaUnit,
-                        defaultLengthUnit: config.widgets.measure.defaultLengthUnit
-                    }, domConstruct.create("div")).placeAt(measureTP.containerNode);
-                    this.measure.startup();
-                    aspect.before(this.measure, 'measureArea', lang.hitch(this, 'setMapClickMode', 'measure'));
-                    aspect.before(this.measure, 'measureDistance', lang.hitch(this, 'setMapClickMode', 'measure'));
-                    aspect.before(this.measure, 'measureLocation', lang.hitch(this, 'setMapClickMode', 'measure'));
-                    aspect.after(this.measure, 'closeTool', lang.hitch(this, 'setMapClickMode', this.config.defaultMapClickMode));
-                }));
-            }
-
-            if (config.widgets.print && config.widgets.print.include) {
-                var printTP = this._createTitlePane(config.widgets.print.title, config.widgets.print.position, config.widgets.print.open);
-                require(['gis/dijit/Print'], lang.hitch(this, function(Print) {
-                    this.printWidget = new Print({
-                        map: this.map,
-                        printTaskURL: config.widgets.print.serviceURL,
-                        authorText: config.widgets.print.authorText,
-                        copyrightText: config.widgets.print.copyrightText,
-                        defaultTitle: config.widgets.print.defaultTitle,
-                        defaultFormat: config.widgets.print.defaultFormat,
-                        defaultLayout: config.widgets.print.defaultLayout
-                    }, domConstruct.create("div")).placeAt(printTP.containerNode);
-                    this.printWidget.startup();
-                }));
-            }
-
-            if (config.widgets.directions && config.widgets.directions.include) {
-                var directionsTP = this._createTitlePane(config.widgets.directions.title, config.widgets.directions.position, config.widgets.directions.open);
-                require(['gis/dijit/Directions'], lang.hitch(this, function(Directions) {
-                    this.directionsWidget = new Directions({
-                        map: this.map,
-                        options: config.widgets.directions.options,
-                        titlePane: directionsTP
-                    }, domConstruct.create("div")).placeAt(directionsTP.containerNode);
-                    this.directionsWidget.startup();
-                }));
-            }
-
-            if (config.widgets.editor && config.widgets.editor.include) {
-                var editorTP = this._createTitlePane(config.widgets.editor.title, config.widgets.editor.position, config.widgets.editor.open);
-                require(['gis/dijit/Editor'], lang.hitch(this, function(Editor) {
-                    this.editor = new Editor({
-                        map: this.map,
-                        mapClickMode: this.mapClickMode,
-                        layerInfos: this.editorLayerInfos,
-                        settings: config.widgets.editor.settings,
-                        titlePane: editorTP
-                    }, domConstruct.create("div")).placeAt(editorTP.containerNode);
-                    this.editor.startup();
-                }));
-            }
+            array.forEach(widgets, function (widget, i) {
+                lang.hitch(this, widgetInitializers[widget.key], widget.config, i)();
+            }, this);
         },
         setMapClickMode: function(mode) {
             this.mapClickMode.current = mode;


### PR DESCRIPTION
Removes requirement for ensuring widget positions are consecutive in config.js.  Code will now sort all included widgets by their configured position, then before initializing assign a new auto-incrementing position to each widget, ensuring no errors are thrown in cases where positions aren't consecutive (i.e. position 0 missing, etc.).

fixes #37
