### PR TITLE
Add back the growler and the geocode widgets

### DIFF
--- a/viewer/js/viewer/Controller.js
+++ b/viewer/js/viewer/Controller.js
@@ -150,6 +150,15 @@ define([
             }
         },
         initWidgets: function(evt) {
+            this.growler = new Growler({}, 'growlerDijit');
+            this.growler.startup();
+
+            this.geocoder = new Geocoder({
+                map: this.map,
+                autoComplete: true
+            }, 'geocodeDijit');
+            this.geocoder.startup();
+
             this.identify = new Identify({
                 identifyTolerance: config.identifyTolerance,
                 map: this.map,


### PR DESCRIPTION
These 2 widgets were unintentionally omitted in PR #63. In this new PR, I add them back to the initWidgets function (instead of initLayers) to consolidate the widget creation into the one function. That seems logical and tests out fine. Creation of baseMap widget still remains in initMap.
