### PR TITLE
added ability to configure multiple panes around the map

### DIFF
--- a/viewer/js/viewer/Controller.js
+++ b/viewer/js/viewer/Controller.js
@@ -32,7 +32,7 @@ define([
             },
             'map': {
                 id: 'map',
-                placeAt: 'inner',
+                placeAt: 'outer',
                 region: 'center',
                 content: mapOverlay
             }
@@ -52,12 +52,6 @@ define([
                 design: 'sidebar',
                 gutters: false
             }).placeAt(win.body());
-            this.panes.inner = new BorderContainer({
-                id: 'innerContainer',
-                region: 'center',
-                design: 'headline',
-                gutters: false
-            }).placeAt(this.panes.outer);
             var options, placeAt, type;
             for (var key in panes) {
                 if (panes.hasOwnProperty(key)) {


### PR DESCRIPTION
added ability to configure multiple panes around the map using a "sidebar" design:
![image](https://cloud.githubusercontent.com/assets/200780/3606494/6caca972-0d37-11e4-880a-a458e21a2305.png)

added new widget type `contentPane` to enable loading a widget as a contentPane into one of the new panes.
