### PR TITLE
reset mapClickMode if StreetViewStatus has Zero_Results

### DIFF
--- a/viewer/js/gis/dijit/StreetView.js
+++ b/viewer/js/gis/dijit/StreetView.js
@@ -141,6 +141,8 @@ define([
             } else if (StreetViewStatus === 'ZERO_RESULTS') {
                 this.setPanoPlace = null;
                 this.clearGraphics();
+                // reset default map click mode
+                this.connectMapClick();
                 domStyle.set(this.noStreetViewResults, 'display', 'block');
             } else {
                 this.setPanoPlace = null;


### PR DESCRIPTION
If the basemap is not in the spatial reference StreetView needs to convert the coordinates then the mapClickMode does not reset to the default mode. The discussion was originally posted here https://github.com/DavidSpriggs/ConfigurableViewerJSAPI/issues/84#issuecomment-48631765

A followup comment by @tmcgee suggested placing my change outside the If statement.
