### PR TITLE
Fixes for Internet Explorer 8 compatibility.

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -51,6 +51,9 @@
                 }]
             };
         </script>
+        <!--[if lt IE 9]>
+            <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/4.0.3/es5-shim.min.js"></script>
+        <![endif]-->
         <script type="text/javascript" src="//js.arcgis.com/3.10compact/"></script>
         <script type="text/javascript">
             // get the config file from the url if present

--- a/viewer/js/gis/dijit/Editor.js
+++ b/viewer/js/gis/dijit/Editor.js
@@ -10,7 +10,7 @@ define([
 ], function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, lang, domConstruct, topic, aspect) {
 
     return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
-        templateString: '<div><div style="text-align:center;"><button data-dojo-type="dijit/form/Button" data-dojo-attach-event="onClick:toggleEditing" data-dojo-props="label:\'Start Editing\',class:\'success\'" data-dojo-attach-point="toggleBTN"></button></div><div class="editDijit" style="margin-top:5px;" data-dojo-attach-point="containerNode"></div></div>',
+        templateString: '<div><div style="text-align:center;"><button data-dojo-type="dijit/form/Button" data-dojo-attach-event="onClick:toggleEditing" data-dojo-props="label:\'Start Editing\',\'class\':\'success\'" data-dojo-attach-point="toggleBTN"></button></div><div class="editDijit" style="margin-top:5px;" data-dojo-attach-point="containerNode"></div></div>',
         widgetsInTemplate: true,
         editor: null,
         isEdit: false,

--- a/viewer/js/gis/dijit/Find/templates/Find.html
+++ b/viewer/js/gis/dijit/Find/templates/Find.html
@@ -3,21 +3,21 @@
         <div data-dojo-type="dijit/form/Form" data-dojo-attach-point="searchFormDijit">
             <div data-dojo-attach-point="querySelectDom">
                 <label>Select A Query:</label><br/>
-    			<input type="select" data-dojo-type="dijit/form/FilteringSelect" data-dojo-props="name:'query',autoComplete:true,required:true,searchAttr:'description',class:'querySelect'"
+    			<input type="select" data-dojo-type="dijit/form/FilteringSelect" data-dojo-props="name:'query',autoComplete:true,required:true,searchAttr:'description','class':'querySelect'"
                 data-dojo-attach-point="querySelectDijit" data-dojo-attach-event="onChange:_onQueryChange"/>
             </div>
             <div data-dojo-attach-point="queryTextDom">
                 <label>Search For Text:</label><br/>
-    			<input type="text" data-dojo-type="dijit/form/ValidationTextBox" data-dojo-attach-point="searchTextDijit" data-dojo-props="name:'searchText',trim:true,required:true,value:'',placeholder:'Enter the text you want to search for.',class:'searchText'" /><br/>
+    			<input type="text" data-dojo-type="dijit/form/ValidationTextBox" data-dojo-attach-point="searchTextDijit" data-dojo-props="name:'searchText',trim:true,required:true,value:'',placeholder:'Enter the text you want to search for.','class':'searchText'" /><br/>
             </div>
             <div data-dojo-attach-point="queryContainsDom">
-                <input type="checkbox" data-dojo-attach-point="containsSearchText" data-dojo-type="dijit/form/CheckBox" data-dojo-props="class:'containsCheck'"/>
+                <input type="checkbox" data-dojo-attach-point="containsSearchText" data-dojo-type="dijit/form/CheckBox" data-dojo-props="'class':'containsCheck'"/>
                 <label>Find Exact Matches Only</label>
             </div>
-			<div data-dojo-type="dijit/form/Button" data-dojo-props="busyLabel:'searching',iconClass:'searchIcon',class:'searchButton'" data-dojo-attach-event="onClick:search" data-dojo-attach-point="searchButtonDijit">
+			<div data-dojo-type="dijit/form/Button" data-dojo-props="busyLabel:'searching',iconClass:'searchIcon','class':'searchButton'" data-dojo-attach-event="onClick:search" data-dojo-attach-point="searchButtonDijit">
 				Search
 			</div>
-			<div data-dojo-type="dijit/form/Button" data-dojo-props="iconClass:'clearIcon',class:'clearButton'" data-dojo-attach-event="onClick:clearResults" data-dojo-attach-point="clearButtonDijit">
+			<div data-dojo-type="dijit/form/Button" data-dojo-props="iconClass:'clearIcon','class':'clearButton'" data-dojo-attach-event="onClick:clearResults" data-dojo-attach-point="clearButtonDijit">
 				Clear
 			</div>
     	</div>

--- a/viewer/js/gis/dijit/Identify/templates/Identify.html
+++ b/viewer/js/gis/dijit/Identify/templates/Identify.html
@@ -2,7 +2,7 @@
     <div class="formContainer">
         <div data-dojo-type="dijit/form/Form" data-dojo-attach-point="identifyFormDijit">
             <label>Choose "All Visible Layers" or a<br/>single layer for identify:</label><br/>
-            <input type="select" data-dojo-type="dijit/form/FilteringSelect" data-dojo-props="name:'identifyLayer',autoComplete:true,required:true,searchAttr:'name',maxHeight:250,class:'identifySelect'"
+            <input type="select" data-dojo-type="dijit/form/FilteringSelect" data-dojo-props="name:'identifyLayer',autoComplete:true,required:true,searchAttr:'name',maxHeight:250,'class':'identifySelect'"
                 data-dojo-attach-point="identifyLayerDijit" />
         </div>
     </div>


### PR DESCRIPTION
dojo 1.9 / 1.10 officially supports IE 8 and higher. IE 8 will not be
supported in dojo 2.0. There are only minor changes required to support
IE8 in CMV so why not do so until dojo 2.0 is available and used by
ESRI.

index.html:
- added conditional es5-shim required by Proj4JS lib with IE8.
- needed for StreetView and MapInfo widgets

Find/Identify/Editor widgets:
- keyword 'class' requires single quotes in data-dojo-props in IE8. This
  is a good idea for all browsers.
