### PR TITLE
added media query lines to LayerControl css

### DIFF
--- a/viewer/js/gis/dijit/LayerControl/css/LayerControl.css
+++ b/viewer/js/gis/dijit/LayerControl/css/LayerControl.css
@@ -122,3 +122,21 @@
 .layerControlDijit .esriLegendServiceLabel {
     display: none;
 }
+/*
+    media queries bootstrap style
+    http://getbootstrap.com/css/#grid-media-queries
+*/
+@media screen and (max-width: 991px) {
+    /* adjust .layerControlIcon on small and extra-small devices. */
+.layerControlDijit .layerControlIcon {
+    font-size: 34px;
+}
+}
+@media screen and (max-width: 767px) {
+    /* adjust .layerControlIcon on extra-small devices (phones) */
+ .layerControlDijit .layerControlIcon {
+    font-size: 52px;
+}
+}
+
+/* end media queries bootstrap style */


### PR DESCRIPTION
Used same concept as in viewer/css/mains.css to adjust font based on screen size
Concept copied from here https://github.com/cmv/cmv-app/blob/master/viewer/css/main.css#L305

My font-size suggestions are only examples taken from my users. Will need to find a good size for various devices if PR is accepted. I received complaints from my users that the screen press on a iPad was not responsive to existing size in v1.3.0
