### PR TITLE
corrected handling of showing help dialog contents on startup.

### DIFF
--- a/viewer/css/main.css
+++ b/viewer/css/main.css
@@ -129,6 +129,10 @@ body, html {
 .sidebarCollapseButtonHorz {
     width: 16px;
     height: 25px;
+    top: 48%;
+    top: -webkit-calc(50% - 12px);
+    top: -moz-calc(50% - 12px);
+    top: -o-calc(50% - 12px);
     top: calc(50% - 12px);
     border-bottom: 1px solid #B5BCC7;
     border-top: 1px solid #B5BCC7;
@@ -136,6 +140,10 @@ body, html {
 .sidebarCollapseButtonVert {
     width: 25px;
     height: 18px;
+    left: 48%;
+    left: -webkit-calc(50% - 12px);
+    left: -moz-calc(50% - 12px);
+    left: -o-calc(50% - 12px);
     left: calc(50% - 12px);
     border-left: 1px solid #B5BCC7;
     border-right: 1px solid #B5BCC7;

--- a/viewer/js/gis/dijit/Help.js
+++ b/viewer/js/gis/dijit/Help.js
@@ -35,11 +35,13 @@ define([
 				on(help, 'click', lang.hitch(this.parentWidget, 'show'));
 			}
 		},
-		onShow: function () {
+		onOpen: function () {
 			//  Make sure the content is visible when the dialog
 			//  is shown/opened. Something like this may be needed
 			//  for all floating windows that don't open on startup?
-			this.containerNode.resize();
+			if (!this.openOnStartup) {
+				this.containerNode.resize();
+			}
 		},
 		close: function () {
 			if (this.parentWidget.hide) {


### PR DESCRIPTION
use cross-browser css 'calc' so sidebar collapse arrows are correctly
positioned in all browsers.
Tested with Chrome, Firefox, IE8/11, Android def browser and iOS Safari.
