### PR TITLE
update to JS API version 3.11.

### DIFF
--- a/viewer/css/main.css
+++ b/viewer/css/main.css
@@ -57,6 +57,8 @@ body, html {
     bottom: 0;
     left: 0;
     right: 0;
+    border: none;
+    padding: 0;
     background-color: #FFFFFF
 }
 #sidebarLeft {

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -7,7 +7,7 @@
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
         <title>Configurable Map Viewer</title>
-        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.10compact/js/esri/css/esri.css">
+        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.11compact/esri/css/esri.css">
         <link rel="stylesheet" type="text/css" href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
         <link rel="stylesheet" type="text/css" href="css/theme/dbootstrap/dbootstrap.css">
         <link rel="stylesheet" type="text/css" href="css/main.css">
@@ -52,7 +52,7 @@
         <!--[if lt IE 9]>
             <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/4.0.3/es5-shim.min.js"></script>
         <![endif]-->
-        <script type="text/javascript" src="//js.arcgis.com/3.10compact/"></script>
+        <script type="text/javascript" src="//js.arcgis.com/3.11compact/"></script>
         <script type="text/javascript">
             // get the config file from the url if present
             var file = 'config/viewer', s = window.location.search, q = s.match(/config=([^&]*)/i);


### PR DESCRIPTION
add css to fix border container issue when gutter = false. This bug was
introduced in dojo 1.10.0 (used in JS API v 3.11). It was subsequently
fixed in dojo 1.10.1 (https://bugs.dojotoolkit.org/ticket/18097).
This css can be removed when ESRI updates to a newer dojo build.
