### PR TITLE
zoom on row click instead of select

### DIFF
--- a/viewer/js/gis/dijit/Find.js
+++ b/viewer/js/gis/dijit/Find.js
@@ -257,7 +257,7 @@ define([
 				}, this.findResultsGrid);
 
 				this.resultsGrid.startup();
-				this.resultsGrid.on('dgrid-select', lang.hitch(this, 'selectFeature'));
+				this.resultsGrid.on('.dgrid-row:click', lang.hitch(this, 'zoomToClickedFeature'));
 			}
 		},
 
@@ -360,24 +360,23 @@ define([
 			}
 		},
 
-		selectFeature: function (event) {
-			var result = event.rows;
 
-			// zoom to feature
-			if (result.length) {
-				var data = result[0].data;
-				if (data) {
-					var feature = data.feature;
-					if (feature) {
-						var extent = feature.geometry.getExtent();
-						if (!extent && feature.geometry.type === 'point') {
-							extent = this.getExtentFromPoint(feature);
-						}
-						if (extent) {
-							this.zoomToExtent(extent);
-						}
-					}
-				}
+		zoomToClickedFeature: function (event) {
+			var row = this.resultsGrid.row(event );
+			var data = row.data;
+
+			var feature = data.feature;
+			if ( !feature ) {
+				return;
+			}
+
+			var extent = feature.geometry.getExtent();
+			if (!extent && feature.geometry.type === 'point') {
+				extent = this.getExtentFromPoint(feature);
+			}
+
+			if (extent) {
+				this.zoomToExtent(extent);
 			}
 		},
 

--- a/viewer/js/gis/dijit/Find.js
+++ b/viewer/js/gis/dijit/Find.js
@@ -374,7 +374,7 @@ define([
 			}
 		},
 
-		getFeatureFromRowEvent: function (rowEvent) {
+		getFeatureFromRowEvent: function (event) {
 			var row = this.resultsGrid.row(event);
 			if (!row){
 				return null;

--- a/viewer/js/gis/dijit/Find.js
+++ b/viewer/js/gis/dijit/Find.js
@@ -257,7 +257,8 @@ define([
 				}, this.findResultsGrid);
 
 				this.resultsGrid.startup();
-				this.resultsGrid.on('.dgrid-row:click', lang.hitch(this, 'zoomToClickedFeature'));
+				this.resultsGrid.on('.dgrid-row:click', lang.hitch(this, 'zoomOnRowClick'));
+				this.resultsGrid.on('.dgrid-row:keyup', lang.hitch(this, 'zoomOnKeyboardNavigation'));
 			}
 		},
 
@@ -360,13 +361,35 @@ define([
 			}
 		},
 
+		zoomOnRowClick: function (event) {
+			var feature = this.getFeatureFromRowEvent(event);
+			this.getFeatureExtentAndZoom(feature);
+		},
 
-		zoomToClickedFeature: function (event) {
-			var row = this.resultsGrid.row(event );
+		zoomOnKeyboardNavigation: function (event){
+			var keyCode = event.keyCode;
+			if ( keyCode === 38 || keyCode === 40 ) {
+				var feature = this.getFeatureFromRowEvent(event);
+				this.getFeatureExtentAndZoom(feature);
+			}
+		},
+
+		getFeatureFromRowEvent: function (rowEvent) {
+			var row = this.resultsGrid.row(event);
+			if (!row){
+				return null;
+			}
+
 			var data = row.data;
+			if (!data) {
+				return null;
+			}
 
-			var feature = data.feature;
-			if ( !feature ) {
+			return data.feature;
+		},
+
+		getFeatureExtentAndZoom: function (feature){
+			if (!feature){
 				return;
 			}
 


### PR DESCRIPTION
use the .dgrid-row:click to handle zooming to clicked feature.  This handles the case where the user has clicked on a feature, then manually panned the map.  Now clicking on the selected feature will pan the map back to the selected feature.