### PR TITLE
Find graphics

### DIFF
--- a/viewer/js/config/find.js
+++ b/viewer/js/config/find.js
@@ -17,13 +17,13 @@ define({
 		}
 	],
 	graphicSymbols: {
-		point:{},
-		polyline:{},
-		polygon:{}
+		//point:{},
+		//polyline:{},
+		//polygon:{}
 	},
 	selectedGraphicSymbols: {
-		point:{},
-		polyline:{},
-		polygon:{}
+		//point:{},
+		//polyline:{},
+		//polygon:{}
 	}
 });

--- a/viewer/js/config/find.js
+++ b/viewer/js/config/find.js
@@ -15,5 +15,15 @@ define({
 			searchFields: ['FCODE', 'DESCRIPTION'],
 			minChars: 4
 		}
-	]
+	],
+	graphicSymbols: {
+		point:{},
+		polyline:{},
+		polygon:{}
+	},
+	selectedGraphicSymbols: {
+		point:{},
+		polyline:{},
+		polygon:{}
+	}
 });

--- a/viewer/js/gis/dijit/Find.js
+++ b/viewer/js/gis/dijit/Find.js
@@ -23,7 +23,7 @@ define([
 	'esri/tasks/FindParameters',
 	'esri/geometry/Extent',
 	'dojo/text!./Find/templates/Find.html',
-	'viewer/js/gis/dijit/Find/symbology/symbols.js',
+	'js/gis/dijit/Find/symbology/symbols.js',
 	'dojo/i18n!./Find/nls/resource',
 	'dijit/form/Form',
 	'dijit/form/FilteringSelect',
@@ -67,9 +67,6 @@ define([
 					this.pointExtentSize = 500; // could be feet or meters
 				}
 			}
-			//console.log("selectionSymbols", this.selectionSymbols);
-			//console.log("defaultSymbols", this.defaultSymbols);
-			//console.log("point", this.defaultSymbols.point);
 
 			this.createGraphicLayers();
 

--- a/viewer/js/gis/dijit/Find.js
+++ b/viewer/js/gis/dijit/Find.js
@@ -191,7 +191,7 @@ define([
 
 		_createGraphicSymbols: function () {
 
-			var symbols = lang.mixin({}, this.defaultGraphicSymbols.graphicSymbols /* declared dependancy */);
+			var symbols = lang.mixin({}, this.defaultGraphicSymbols.graphicSymbols /* declared dependency */);
 
 			for (geometryType in symbols /* from config */){
 
@@ -206,7 +206,7 @@ define([
 
 		_createSelectedGraphicSymbols: function () {
 
-			var symbols = lang.mixin({}, this.defaultGraphicSymbols.selectedGraphicSymbols /* declared dependancy */);
+			var symbols = lang.mixin({}, this.defaultGraphicSymbols.selectedGraphicSymbols /* declared dependency */);
 
 			for (geometryType in symbols /* from config */ ){
 

--- a/viewer/js/gis/dijit/Find.js
+++ b/viewer/js/gis/dijit/Find.js
@@ -23,14 +23,14 @@ define([
 	'esri/tasks/FindParameters',
 	'esri/geometry/Extent',
 	'dojo/text!./Find/templates/Find.html',
-	'js/gis/dijit/Find/symbology/symbols.js',
+	'js/gis/dijit/Find/symbology/DefaultGraphicSymbols.js',
 	'dojo/i18n!./Find/nls/resource',
 	'dijit/form/Form',
 	'dijit/form/FilteringSelect',
 	'dijit/form/ValidationTextBox',
 	'dijit/form/CheckBox',
 	'xstyle/css!./Find/css/Find.css'
-], function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, domConstruct, lang, array, on, keys, Memory, OnDemandGrid, Selection, Keyboard, GraphicsLayer, Graphic, SimpleRenderer, SimpleMarkerSymbol, SimpleLineSymbol, SimpleFillSymbol, graphicsUtils, FindTask, FindParameters, Extent, FindTemplate, symbols, i18n) {
+], function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, domConstruct, lang, array, on, keys, Memory, OnDemandGrid, Selection, Keyboard, GraphicsLayer, Graphic, SimpleRenderer, SimpleMarkerSymbol, SimpleLineSymbol, SimpleFillSymbol, graphicsUtils, FindTask, FindParameters, Extent, FindTemplate, DefaultGraphicSymbols, i18n) {
 	return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
 		widgetsInTemplate: true,
 		templateString: FindTemplate,
@@ -44,15 +44,7 @@ define([
 		// or 500 for meters/feet
 		pointExtentSize: null,
 
-		symbols: symbols,
-		resultsSymbols: null,
-		selectionSymbols: null,
-
-
-
-
-
-
+		defaultGraphicSymbols: DefaultGraphicSymbols,
 
 
 		postCreate: function () {
@@ -102,8 +94,9 @@ define([
 		createGraphicLayers: function () {
 
 			// handle each property to preserve as much of the object heirarchy as possible
-			resultsSymbols = lang.mixin(symbols.resultsSymbols, this.resultsSymbols);
-			selectionSymbols = lang.mixin(symbols.selectionSymbols, this.selectionSymbols);
+			var graphicSymbols =  this._createGraphicSymbols();
+			var selectedGraphicSymbols = this._createSelectedGraphicSymbols();
+
 
 			// points
 			this.pointResultsGraphics = new GraphicsLayer({
@@ -111,21 +104,23 @@ define([
 				title: 'Find'
 			});
 
-			if (resultsSymbols.point) {
-				pointResultsSymbol = new SimpleMarkerSymbol(resultsSymbols.point);
+			if (graphicSymbols.point) {
+				pointResultsSymbol = new SimpleMarkerSymbol(graphicSymbols.point);
 				pointResultsRenderer = new SimpleRenderer(pointResultsSymbol);
 				pointResultsRenderer.label = 'Find Results (Points)';
 				pointResultsRenderer.description = 'Find results (Points)';
 				this.pointResultsGraphics.setRenderer(pointResultsRenderer);
 			}
 
+
+
 			this.pointSelectionGraphics = new GraphicsLayer({
 				id: this.id + '_findSelectionGraphics_point',
 				title: 'Selection'
 			});
 
-			if (selectionSymbols.point) {
-				pointSelectionSymbol = new SimpleMarkerSymbol(selectionSymbols.point);
+			if (selectedGraphicSymbols.point) {
+				pointSelectionSymbol = new SimpleMarkerSymbol(selectedGraphicSymbols.point);
 				pointSelectionRenderer = new SimpleRenderer(pointSelectionSymbol);
 				pointSelectionRenderer.label = 'Selection (Points)';
 				pointSelectionRenderer.description = 'Selection (Points)';
@@ -138,8 +133,8 @@ define([
 				title: 'Find Graphics'
 			});
 
-			if (resultsSymbols.polyline) {
-				polylineResultsSymbol = new SimpleLineSymbol(resultsSymbols.polyline);
+			if (graphicSymbols.polyline) {
+				polylineResultsSymbol = new SimpleLineSymbol(graphicSymbols.polyline);
 				polylineResultsRenderer = new SimpleRenderer(polylineResultsSymbol);
 				polylineResultsRenderer.label = 'Find Results (Lines)';
 				polylineResultsRenderer.description = 'Find Results (Lines)';
@@ -151,8 +146,8 @@ define([
 				title: 'Selection'
 			});
 
-			if (selectionSymbols.polyline) {
-				polylineSelectionSymbol = new SimpleLineSymbol(selectionSymbols.polyline);
+			if (selectedGraphicSymbols.polyline) {
+				polylineSelectionSymbol = new SimpleLineSymbol(selectedGraphicSymbols.polyline);
 				polylineSelectionRenderer = new SimpleRenderer(polylineSelectionSymbol);
 				polylineSelectionRenderer.label = 'Selection + (Lines)';
 				polylineSelectionRenderer.description = 'Selection (Lines)';
@@ -165,8 +160,8 @@ define([
 				title: 'Find Graphics'
 			});
 
-			if (resultsSymbols.polygon) {
-				polygonSymbol = new SimpleFillSymbol(resultsSymbols.polygon);
+			if (graphicSymbols.polygon) {
+				polygonSymbol = new SimpleFillSymbol(graphicSymbols.polygon);
 				polygonRenderer = new SimpleRenderer(polygonSymbol);
 				polygonRenderer.label = 'Find Results (Polygons)';
 				polygonRenderer.description = 'Find Results (Polygons)';
@@ -178,8 +173,8 @@ define([
 				title: 'Selection'
 			});
 
-			if (selectionSymbols.polygon) {
-				polygonSelectionSymbol = new SimpleFillSymbol(selectionSymbols.polygon);
+			if (selectedGraphicSymbols.polygon) {
+				polygonSelectionSymbol = new SimpleFillSymbol(selectedGraphicSymbols.polygon);
 				polygonSelectionRenderer = new SimpleRenderer(polygonSelectionSymbol);
 				polygonSelectionRenderer.label = 'Selection (Polygons)';
 				polygonSelectionRenderer.description = 'Selection (Polygons)';
@@ -193,6 +188,26 @@ define([
 			this.map.addLayer(this.polylineSelectionGraphics);
 			this.map.addLayer(this.pointSelectionGraphics);
 		},
+
+		_createGraphicSymbols: function () {
+
+			var symbols = lang.mixin({}, this.defaultGraphicSymbols.graphicSymbols /* declared as dependancy on Find/DefaultGraphicSymbols.js */,
+				this.graphicSymbols /* from config */
+			);
+			return symbols;
+
+		},
+
+		_createSelectedGraphicSymbols: function () {
+
+			var symbols = lang.mixin({}, this.defaultGraphicSymbols.selectedGraphicSymbols /* declared as dependancy on Find/DefaultGraphicSymbols.js */,
+				this.selectedGraphicSymbols /* from config */
+
+			);
+			return symbols;
+
+		},
+
 		search: function () {
 			var query = this.queries[this.queryIdx];
 			var searchText = this.searchTextDijit.get('value');

--- a/viewer/js/gis/dijit/Find.js
+++ b/viewer/js/gis/dijit/Find.js
@@ -45,8 +45,9 @@ define([
 		pointExtentSize: null,
 
 		symbols: symbols,
-		defaultSymbols: symbols.defaultSymbols,
-		selectionSymbols: symbols.selectionSymbols,
+		resultsSymbols: null,
+		selectionSymbols: null,
+
 
 
 
@@ -99,120 +100,98 @@ define([
 		},
 
 		createGraphicLayers: function () {
-			var pointSymbol = null,
-				polylineSymbol = null,
-				polygonSymbol = null;
-			var pointRenderer = null,
-				polylineRenderer = null,
-				polygonRenderer = null;
-			var pointSymbolSel = null,
-				polylineSymbolSel = null,
-				polygonSymbolSel = null;
-			var pointRendererSel = null,
-				polylineRendererSel = null,
-				polygonRendererSel = null;
 
-			var symbols = lang.mixin({}, this.symbols),
-				symbolsSel = lang.mixin({}, this.symbols);
 			// handle each property to preserve as much of the object heirarchy as possible
-			symbols = {
-				point: lang.mixin(this.defaultSymbols.point, symbols.point),
-				polyline: lang.mixin(this.defaultSymbols.polyline, symbols.polyline),
-				polygon: lang.mixin(this.defaultSymbols.polygon, symbols.polygon)
-			};
-			symbolsSel = {
-				point: lang.mixin(this.selectionSymbols.point, symbolsSel.point),
-				polyline: lang.mixin(this.selectionSymbols.polyline, symbolsSel.polyline),
-				polygon: lang.mixin(this.selectionSymbols.polygon, symbolsSel.polygon)
-			};
+			resultsSymbols = lang.mixin(this.resultsSymbols, symbols.resultsSymbols);
+			selectionSymbols = lang.mixin(this.selectionSymbols, symbols.selectionSymbols);
 
 			// points
-			this.pointGraphics = new GraphicsLayer({
-				id: 'findGraphics_point',
+			this.pointResultsGraphics = new GraphicsLayer({
+				id: 'findResultsGraphics_point',
 				title: 'Find'
 			});
 
-			if (symbols.point) {
-				pointSymbol = new SimpleMarkerSymbol(symbols.point);
-				pointRenderer = new SimpleRenderer(pointSymbol);
-				pointRenderer.label = 'Find Results (Points)';
-				pointRenderer.description = 'Find results (Points)';
-				this.pointGraphics.setRenderer(pointRenderer);
+			if (resultsSymbols.point) {
+				pointResultsSymbol = new SimpleMarkerSymbol(resultsSymbols.point);
+				pointResultsRenderer = new SimpleRenderer(pointResultsSymbol);
+				pointResultsRenderer.label = 'Find Results (Points)';
+				pointResultsRenderer.description = 'Find results (Points)';
+				this.pointResultsGraphics.setRenderer(pointResultsRenderer);
 			}
 
-			this.pointGraphicsSel = new GraphicsLayer({
-				id: this.id + '_findGraphics_pointSel',
+			this.pointSelectionGraphics = new GraphicsLayer({
+				id: this.id + '_findSelectionGraphics_point',
 				title: 'Selection'
 			});
 
-			if (symbolsSel.point) {
-				pointSymbolSel = new SimpleMarkerSymbol(symbolsSel.point);
-				pointRendererSel = new SimpleRenderer(pointSymbolSel);
-				pointRendererSel.label = 'Selection (Points)';
-				pointRendererSel.description = 'Selection (Points)';
-				this.pointGraphicsSel.setRenderer(pointRendererSel);
+			if (selectionSymbols.point) {
+				pointSelectionSymbol = new SimpleMarkerSymbol(selectionSymbols.point);
+				pointSelectionRenderer = new SimpleRenderer(pointSelectionSymbol);
+				pointSelectionRenderer.label = 'Selection (Points)';
+				pointSelectionRenderer.description = 'Selection (Points)';
+				this.pointSelectionGraphics.setRenderer(pointSelectionRenderer);
 			}
 
 			// poly line
-			this.polylineGraphics = new GraphicsLayer({
-				id: 'findGraphics_line',
+			this.polylineResultsGraphics = new GraphicsLayer({
+				id: 'findResultsGraphics_line',
 				title: 'Find Graphics'
 			});
 
-			if (symbols.polyline) {
-				polylineSymbol = new SimpleLineSymbol(symbols.polyline);
-				polylineRenderer = new SimpleRenderer(polylineSymbol);
-				polylineRenderer.label = 'Find Results (Lines)';
-				polylineRenderer.description = 'Find Results (Lines)';
-				this.polylineGraphics.setRenderer(polylineRenderer);
+			if (resultsSymbols.polyline) {
+				polylineResultsSymbol = new SimpleLineSymbol(resultsSymbols.polyline);
+				polylineResultsRenderer = new SimpleRenderer(polylineResultsSymbol);
+				polylineResultsRenderer.label = 'Find Results (Lines)';
+				polylineResultsRenderer.description = 'Find Results (Lines)';
+				this.polylineResultsGraphics.setRenderer(polylineResultsRenderer);
 			}
 
-			this.polylineGraphicsSel = new GraphicsLayer({
-				id: this.id + '_findGraphics_lineSel',
+			this.polylineSelectionGraphics = new GraphicsLayer({
+				id: this.id + '_findSelectionGraphics_line',
 				title: 'Selection'
 			});
 
-			if (symbolsSel.polyline) {
-				polylineSymbolSel = new SimpleLineSymbol(symbolsSel.polyline);
-				polylineRendererSel = new SimpleRenderer(polylineSymbolSel);
-				polylineRendererSel.label = 'Selection + (Lines)';
-				polylineRendererSel.description = 'Selection (Lines)';
-				this.polylineGraphicsSel.setRenderer(polylineRendererSel);
+			if (selectionSymbols.polyline) {
+				polylineSelectionSymbol = new SimpleLineSymbol(selectionSymbols.polyline);
+				polylineSelectionRenderer = new SimpleRenderer(polylineSelectionSymbol);
+				polylineSelectionRenderer.label = 'Selection + (Lines)';
+				polylineSelectionRenderer.description = 'Selection (Lines)';
+				this.polylineSelectionGraphics.setRenderer(polylineSelectionRenderer);
 			}
 
 			// polygons
-			this.polygonGraphics = new GraphicsLayer({
-				id: 'findGraphics_polygon',
+			this.polygonResultsGraphics = new GraphicsLayer({
+				id: 'findResultsGraphics_polygon',
 				title: 'Find Graphics'
 			});
 
-			if (symbols.polygon) {
-				polygonSymbol = new SimpleFillSymbol(symbols.polygon);
+			if (resultsSymbols.polygon) {
+				polygonSymbol = new SimpleFillSymbol(resultsSymbols.polygon);
 				polygonRenderer = new SimpleRenderer(polygonSymbol);
 				polygonRenderer.label = 'Find Results (Polygons)';
 				polygonRenderer.description = 'Find Results (Polygons)';
-				this.polygonGraphics.setRenderer(polygonRenderer);
+				this.polygonResultsGraphics.setRenderer(polygonRenderer);
 			}
 
-			this.polygonGraphicsSel = new GraphicsLayer({
-				id: this.id + '_findGraphics_polygonSel',
+			this.polygonSelectionGraphics = new GraphicsLayer({
+				id: this.id + '_findSelectionGraphics_polygon',
 				title: 'Selection'
 			});
 
-			if (symbolsSel.polygon) {
-				polygonSymbolSel = new SimpleFillSymbol(symbolsSel.polygon);
-				polygonRendererSel = new SimpleRenderer(polygonSymbolSel);
-				polygonRendererSel.label = 'Selection (Polygons)';
-				polygonRendererSel.description = 'Selection (Polygons)';
-				this.polygonGraphicsSel.setRenderer(polygonRendererSel);
+			if (selectionSymbols.polygon) {
+				polygonSelectionSymbol = new SimpleFillSymbol(selectionSymbols.polygon);
+				polygonSelectionRenderer = new SimpleRenderer(polygonSelectionSymbol);
+				polygonSelectionRenderer.label = 'Selection (Polygons)';
+				polygonSelectionRenderer.description = 'Selection (Polygons)';
+				this.polygonSelectionGraphics.setRenderer(polygonSelectionRenderer);
 			}
 
-			this.map.addLayer(this.polygonGraphics);
-			this.map.addLayer(this.polylineGraphics);
-			this.map.addLayer(this.pointGraphics);
-			this.map.addLayer(this.polygonGraphicsSel);
-			this.map.addLayer(this.polylineGraphicsSel);
-			this.map.addLayer(this.pointGraphicsSel);
+			this.map.addLayer(this.polygonResultsGraphics);
+			this.map.addLayer(this.polylineResultsGraphics);
+			this.map.addLayer(this.pointResultsGraphics);
+			this.map.addLayer(this.polygonSelectionGraphics);
+			this.map.addLayer(this.polylineSelectionGraphics);
+			this.map.addLayer(this.pointSelectionGraphics);
 		},
 		search: function () {
 			var query = this.queries[this.queryIdx];
@@ -337,14 +316,14 @@ define([
 						// only add points to the map that have an X/Y
 						if (feature.geometry.x && feature.geometry.y) {
 							graphic = new Graphic(feature.geometry);
-							this.pointGraphics.add(graphic);
+							this.pointResultsGraphics.add(graphic);
 						}
 						break;
 					case 'polyline':
 						// only add polylines to the map that have paths
 						if (feature.geometry.paths && feature.geometry.paths.length > 0) {
 							graphic = new Graphic(feature.geometry);
-							this.polylineGraphics.add(graphic);
+							this.polylineResultsGraphics.add(graphic);
 						}
 						break;
 					case 'polygon':
@@ -353,7 +332,7 @@ define([
 							graphic = new Graphic(feature.geometry, null, {
 								ren: 1
 							});
-							this.polygonGraphics.add(graphic);
+							this.polygonResultsGraphics.add(graphic);
 						}
 						break;
 					default:
@@ -366,21 +345,21 @@ define([
 			// if there are no features in the layer then extents are null
 			// the result of union() to null extents is null
 
-			if (this.pointGraphics.graphics.length > 0) {
-				zoomExtent = this.getPointFeaturesExtent(this.pointGraphics.graphics);
+			if (this.pointResultsGraphics.graphics.length > 0) {
+				zoomExtent = this.getPointFeaturesExtent(this.pointResultsGraphics.graphics);
 			}
-			if (this.polylineGraphics.graphics.length > 0) {
+			if (this.polylineResultsGraphics.graphics.length > 0) {
 				if (zoomExtent === null) {
-					zoomExtent = graphicsUtils.graphicsExtent(this.polylineGraphics.graphics);
+					zoomExtent = graphicsUtils.graphicsExtent(this.polylineResultsGraphics.graphics);
 				} else {
-					zoomExtent = zoomExtent.union(graphicsUtils.graphicsExtent(this.polylineGraphics.graphics));
+					zoomExtent = zoomExtent.union(graphicsUtils.graphicsExtent(this.polylineResultsGraphics.graphics));
 				}
 			}
-			if (this.polygonGraphics.graphics.length > 0) {
+			if (this.polygonResultsGraphics.graphics.length > 0) {
 				if (zoomExtent === null) {
-					zoomExtent = graphicsUtils.graphicsExtent(this.polygonGraphics.graphics);
+					zoomExtent = graphicsUtils.graphicsExtent(this.polygonResultsGraphics.graphics);
 				} else {
-					zoomExtent = zoomExtent.union(graphicsUtils.graphicsExtent(this.polygonGraphics.graphics));
+					zoomExtent = zoomExtent.union(graphicsUtils.graphicsExtent(this.polygonResultsGraphics.graphics));
 				}
 			}
 
@@ -421,14 +400,14 @@ define([
 					// only add points to the map that have an X/Y
 					if (feature.geometry.x && feature.geometry.y) {
 						graphic = new Graphic(feature.geometry);
-						this.pointGraphicsSel.add(graphic);
+						this.pointSelectionGraphics.add(graphic);
 					}
 					break;
 				case 'polyline':
 					// only add polylines to the map that have paths
 					if (feature.geometry.paths && feature.geometry.paths.length > 0) {
 						graphic = new Graphic(feature.geometry);
-						this.polylineGraphicsSel.add(graphic);
+						this.polylineSelectionGraphics.add(graphic);
 					}
 					break;
 				case 'polygon':
@@ -437,7 +416,7 @@ define([
 						graphic = new Graphic(feature.geometry, null, {
 							ren: 1
 						});
-						this.polygonGraphicsSel.add(graphic);
+						this.polygonSelectionGraphics.add(graphic);
 					}
 					break;
 				default:
@@ -487,16 +466,16 @@ define([
 		},
 
 		clearFeatures: function () {
-			this.pointGraphics.clear();
-			this.polylineGraphics.clear();
-			this.polygonGraphics.clear();
+			this.pointResultsGraphics.clear();
+			this.polylineResultsGraphics.clear();
+			this.polygonResultsGraphics.clear();
 			this.clearSelectionFeatures();
 		},
 
 		clearSelectionFeatures: function () {
-			this.pointGraphicsSel.clear();
-			this.polylineGraphicsSel.clear();
-			this.polygonGraphicsSel.clear();
+			this.pointSelectionGraphics.clear();
+			this.polylineSelectionGraphics.clear();
+			this.polygonSelectionGraphics.clear();
 		},
 
 		getPointFeaturesExtent: function (pointFeatures) {

--- a/viewer/js/gis/dijit/Find.js
+++ b/viewer/js/gis/dijit/Find.js
@@ -102,8 +102,8 @@ define([
 		createGraphicLayers: function () {
 
 			// handle each property to preserve as much of the object heirarchy as possible
-			resultsSymbols = lang.mixin(this.resultsSymbols, symbols.resultsSymbols);
-			selectionSymbols = lang.mixin(this.selectionSymbols, symbols.selectionSymbols);
+			resultsSymbols = lang.mixin(symbols.resultsSymbols, this.resultsSymbols);
+			selectionSymbols = lang.mixin(symbols.selectionSymbols, this.selectionSymbols);
 
 			// points
 			this.pointResultsGraphics = new GraphicsLayer({

--- a/viewer/js/gis/dijit/Find.js
+++ b/viewer/js/gis/dijit/Find.js
@@ -23,7 +23,7 @@ define([
 	'esri/tasks/FindParameters',
 	'esri/geometry/Extent',
 	'dojo/text!./Find/templates/Find.html',
-	'js/gis/dijit/Find/symbology/DefaultGraphicSymbols.js',
+	'./Find/symbology/DefaultGraphicSymbols',
 	'dojo/i18n!./Find/nls/resource',
 	'dijit/form/Form',
 	'dijit/form/FilteringSelect',
@@ -191,19 +191,30 @@ define([
 
 		_createGraphicSymbols: function () {
 
-			var symbols = lang.mixin({}, this.defaultGraphicSymbols.graphicSymbols /* declared as dependancy on Find/DefaultGraphicSymbols.js */,
-				this.graphicSymbols /* from config */
-			);
+			var symbols = lang.mixin({}, this.defaultGraphicSymbols.graphicSymbols /* declared dependancy */);
+
+			for (geometryType in symbols /* from config */){
+
+				if (this.graphicSymbols.hasOwnProperty( geometryType )){
+					symbols[ geometryType ] = this.graphicSymbols[ geometryType];
+ 				}
+			}
+
 			return symbols;
 
 		},
 
 		_createSelectedGraphicSymbols: function () {
 
-			var symbols = lang.mixin({}, this.defaultGraphicSymbols.selectedGraphicSymbols /* declared as dependancy on Find/DefaultGraphicSymbols.js */,
-				this.selectedGraphicSymbols /* from config */
+			var symbols = lang.mixin({}, this.defaultGraphicSymbols.selectedGraphicSymbols /* declared dependancy */);
 
-			);
+			for (geometryType in symbols /* from config */ ){
+
+				if ( this.selectedGraphicSymbols.hasOwnProperty( geometryType )){
+					symbols[ geometryType ] = this.selectedGraphicSymbols[ geometryType ]
+				}
+			}
+
 			return symbols;
 
 		},

--- a/viewer/js/gis/dijit/Find/symbology/DefaultGraphicSymbols.js
+++ b/viewer/js/gis/dijit/Find/symbology/DefaultGraphicSymbols.js
@@ -1,5 +1,5 @@
 define({
-    resultsSymbols: {
+    graphicSymbols: {
         point: {
             type: 'esriSMS',
             style: 'esriSMSCircle',
@@ -33,7 +33,7 @@ define({
             }
         }
     },
-    selectionSymbols: {
+    selectedGraphicSymbols: {
         point: {
             type: 'esriSMS',
             style: 'esriSMSCircle',

--- a/viewer/js/gis/dijit/Find/symbology/symbols.js
+++ b/viewer/js/gis/dijit/Find/symbology/symbols.js
@@ -1,0 +1,71 @@
+define({
+    defaultSymbols: {
+        point: {
+            type: 'esriSMS',
+            style: 'esriSMSCircle',
+            size: 25,
+            color: [0, 255, 255, 32],
+            angle: 0,
+            xoffset: 0,
+            yoffset: 0,
+            outline: {
+                type: 'esriSLS',
+                style: 'esriSLSSolid',
+                color: [0, 255, 255, 255],
+                width: 2
+            }
+        },
+        polyline: {
+            type: 'esriSLS',
+            style: 'esriSLSSolid',
+            color: [0, 255, 255, 255],
+            width: 3
+        },
+        polygon: {
+            type: 'esriSFS',
+            style: 'esriSFSSolid',
+            color: [0, 255, 255, 32],
+            outline: {
+                type: 'esriSLS',
+                style: 'esriSLSSolid',
+                color: [0, 255, 255, 255],
+                width: 3
+            }
+        }
+    },
+    selectionSymbols: {
+        point: {
+            type: 'esriSMS',
+            style: 'esriSMSCircle',
+            size: 25,
+            color: [4, 156, 219, 32],
+            angle: 0,
+            xoffset: 0,
+            yoffset: 0,
+            outline: {
+                type: 'esriSLS',
+                style: 'esriSLSSolid',
+                color: [4, 156, 219, 255],
+                width: 2
+            }
+        },
+        polyline: {
+            type: 'esriSLS',
+            style: 'esriSLSSolid',
+            color: [4, 156, 219, 255],
+            width: 3
+        },
+        polygon: {
+            type: 'esriSFS',
+            style: 'esriSFSSolid',
+            color: [4, 156, 219, 32],
+            outline: {
+                type: 'esriSLS',
+                style: 'esriSLSSolid',
+                color: [4, 156, 219, 255],
+                width: 3
+            }
+        }
+    }});
+
+

--- a/viewer/js/gis/dijit/Find/symbology/symbols.js
+++ b/viewer/js/gis/dijit/Find/symbology/symbols.js
@@ -1,5 +1,5 @@
 define({
-    defaultSymbols: {
+    resultsSymbols: {
         point: {
             type: 'esriSMS',
             style: 'esriSMSCircle',


### PR DESCRIPTION
I've configured the Find widget to have separate graphics layers for both the results features and the currently selected feature. This helps to identify the selected feature when the results have a high density. The default symbology for the find widget is in a dependent file that is mixed in with an optional symbology from the find configuration. This allows a user to have separate find functions each with their own symbology. 

