### PR TITLE
Map Mixin

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -63,7 +63,7 @@
                 }
             }
             require(['viewer/Controller', file], function(Controller, config){
-                Controller.startup(config);
+                new Controller(config);
             });
         </script>
     </body>

--- a/viewer/js/viewer/core/_MapMixin.js
+++ b/viewer/js/viewer/core/_MapMixin.js
@@ -1,0 +1,119 @@
+define([
+	'dojo/on',
+	'dojo/_base/declare',
+	'esri/map',
+	'dojo/_base/array',
+	'dojo/Deferred',
+	'dojo/_base/lang',
+	'dojo/aspect'
+], function (on, declare, Map, array, Deferred, lang) {
+
+	return declare(null, {
+	 
+	 	constructor: function() {
+			
+	 	},
+
+		initMapAsync: function () {
+			var returnDeferred = new Deferred();
+			var returnWarnings = [];
+			this.map = new Map('mapCenter', this.config.mapOptions);
+			if (this.config.mapOptions.basemap) {
+				this.map.on('load', lang.hitch(this, '_initLayers', returnWarnings));
+			} else {
+				this._initLayers(returnWarnings);
+			}
+			if (this.config.operationalLayers && this.config.operationalLayers.length > 0) {
+				on.once(this.map, 'layers-add-result', lang.hitch(this, '_onLayersAddResult', returnDeferred, returnWarnings));
+			} else {
+				returnDeferred.resolve(returnWarnings);
+			}
+			return returnDeferred;
+		},
+		
+		_onLayersAddResult: function(returnDeferred, returnWarnings, lyrsResult) {
+			array.forEach(lyrsResult.layers, function (addedLayer) {
+				if (addedLayer.success !== true) {
+					returnWarnings.push(addedLayer.error);
+				}
+			}, this);
+			returnDeferred.resolve(returnWarnings);
+		},
+		
+		_initLayers: function (returnWarnings) {
+			this.layers = [];
+			var layerTypes = {
+				csv: 'CSV',
+				dynamic: 'ArcGISDynamicMapService',
+				feature: 'Feature',
+				georss: 'GeoRSS',
+				image: 'ArcGISImageService',
+				kml: 'KML',
+				label: 'Label', //untested
+				mapimage: 'MapImage', //untested
+				osm: 'OpenStreetMap',
+				tiled: 'ArcGISTiledMapService',
+				wms: 'WMS',
+				wmts: 'WMTS' //untested
+			};
+			// loading all the required modules first ensures the layer order is maintained
+			var modules = [];
+			array.forEach(this.config.operationalLayers, function (layer) {
+				var type = layerTypes[layer.type];
+				if (type) {
+					modules.push('esri/layers/' + type + 'Layer');
+				} else {
+					returnWarnings.push('Layer type "' + layer.type + '"" isnot supported: ');
+				}
+			}, this);
+			require(modules, lang.hitch(this, function () {
+				array.forEach(this.config.operationalLayers, function (layer) {
+					var type = layerTypes[layer.type];
+					if (type) {
+						require(['esri/layers/' + type + 'Layer'], lang.hitch(this, '_initLayer', layer));
+					}
+				}, this);
+				this.map.addLayers(this.layers);
+			}));
+		},
+		
+		_initLayer: function (layer, Layer) {
+			var l = new Layer(layer.url, layer.options);
+			this.layers.unshift(l); //unshift instead of push to keep layer ordering on map intact
+			//Legend LayerInfos array
+			this.legendLayerInfos.unshift({ //unshift instead of push to keep layer ordering in legend intact
+				layer: l,
+				title: layer.title || null
+			});
+			//LayerControl LayerInfos array
+			this.layerControlLayerInfos.unshift({ //unshift instead of push to keep layer ordering in LayerControl intact
+				layer: l,
+				type: layer.type,
+				title: layer.title,
+				controlOptions: layer.layerControlLayerInfos
+			});
+			if (layer.type === 'feature') {
+				var options = {
+					featureLayer: l
+				};
+				if (layer.editorLayerInfos) {
+					lang.mixin(options, layer.editorLayerInfos);
+				}
+				this.editorLayerInfos.push(options);
+			}
+			if (layer.type === 'dynamic' || layer.type === 'feature') {
+				var idOptions = {
+					layer: l,
+					title: layer.title
+				};
+				if (layer.identifyLayerInfos) {
+					lang.mixin(idOptions, layer.identifyLayerInfos);
+				}
+				if (idOptions.exclude !== true) {
+					this.identifyLayerInfos.push(idOptions);
+				}
+			}
+		}
+
+	});
+});


### PR DESCRIPTION
I created a mixin to encapsulate the MapLoader logic. I used a Mixin rather than factoring out the MapLoader, as discussed in PR #395. I borrowed heavily from @DavidSpriggs controller-with-mixins-dave branch (how to reference?).
 1. Made the initMap method async, and named it such, so that a custom mixin could accommodate creating a map from AGO. 
 2. Handled the layers-add-result event, checking the status of each added layer. 
 3. Created "warnings" to preserve the existing behaviour which allowed the map to load even if one or more layers were invalid. 
 4. Delayed second stage of building Panes because **for an async map**, the "this.map" object is not created until after the map is loaded. The panes code is not too clear for me, so I did not refactor this, and this may need deeper review from somebody more familiar.
 5. Moved the switch to Mobile Popup out of the initMap method, because it didn't seem like it should be part of the Mixin, but rather the Controller.

Also:
* Branched from develop, to fix mistake in #394 when I branched from master, and did a PR to master.
* Avoided anonymous functions, as discussed in #395.