### PR TITLE
CmvMenu

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -32,6 +32,8 @@
             <div class="headerLinks">
                 <div id="helpDijit">
                 </div>
+                <div id="cmvMenu" class="cmvMenuContainer">
+                </div>
             </div>
         </div>
         <script type="text/javascript">

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -30,8 +30,6 @@
                 </div>
             </div>
             <div class="headerLinks">
-                <div id="helpDijit">
-                </div>
                 <div id="cmvMenu">
                 </div>
             </div>

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -32,7 +32,7 @@
             <div class="headerLinks">
                 <div id="helpDijit">
                 </div>
-                <div id="cmvMenu" class="cmvMenuContainer">
+                <div id="cmvMenu">
                 </div>
             </div>
         </div>

--- a/viewer/js/config/viewer.js
+++ b/viewer/js/config/viewer.js
@@ -116,6 +116,108 @@ define([
   }],
         // set include:true to load. For titlePane type set position the the desired order in the sidebar
         widgets: {
+            cmvmenu: {
+                include: true,
+                id: 'cmvmenu',
+                type: 'domNode',
+                srcNodeRef: 'cmvMenu',
+                path: 'gis/dijit/CmvMenuWidget',
+                options: {
+                    // iconHeight
+                    // height
+                    widgets: [
+                        {
+                            id: 'identify',
+                            title: 'Identify',
+                            icon: '/js/gis/dijit/Identify/images/identify.png',
+                            group: 'group1'
+                        },
+                        {
+                            id: 'legend',
+                            title: 'Legend',
+                            icon: null,
+                            group: 'group2'
+                        }, 
+                        {
+                            id: 'layerControl',
+                            title: 'Layers',
+                            icon: null,
+                            group: 'group2'
+                        }, 
+                        {
+                            id: 'bookmarks',
+                            title: 'Bookmarks',
+                            icon: null,
+                            group: 'group3'
+                        },
+                        {
+                            id: 'measurement',
+                            title: 'Measure',
+                            open: false,
+                            group: 'group3'
+                        }
+                    ]
+                }
+            },
+            identify: {
+                include: true,
+                id: 'identify',
+                type: 'gis/dijit/FloatingWidgetPanel',
+                srcNodeRef: 'cmvMenuNode',
+                path: 'gis/dijit/Identify',
+                title: 'Identify',
+                options: 'config/identify'
+            },
+            legend: {
+                include: true,
+                id: 'legend',
+                type: 'gis/dijit/FloatingWidgetPanel',
+                srcNodeRef: 'cmvMenuNode',
+                path: 'esri/dijit/Legend',
+                title: 'Legend',
+                options: {
+                    map: true,
+                    legendLayerInfos: true
+                }
+            }, 
+            layers: {
+                include: true,
+                id: 'layerControl',
+                type: 'gis/dijit/FloatingWidgetPanel',
+                srcNodeRef: 'cmvMenuNode',
+                path: 'gis/dijit/LayerControl',
+                title: 'Layers',
+                options: {
+                    map: true,
+                    layerControlLayerInfos: true,
+                    separated: true,
+                    vectorReorder: true,
+                    overlayReorder: true
+                }
+            }, 
+            bookmarks: {
+                include: true,
+                id: 'bookmarks',
+                type: 'gis/dijit/FloatingWidgetPanel',
+                srcNodeRef: 'cmvMenuNode',
+                path: 'gis/dijit/Bookmarks',
+                title: 'Bookmarks',
+                options: 'config/bookmarks'
+            },
+            measure: {
+                include: true,
+                id: 'measurement',
+                type: 'gis/dijit/FloatingWidgetPanel',
+                srcNodeRef: 'cmvMenuNode',
+                path: 'gis/dijit/Measurement',
+                title: 'Measurement',
+                options: {
+                    map: true,
+                    mapClickMode: true,
+                    defaultAreaUnit: units.SQUARE_MILES,
+                    defaultLengthUnit: units.MILES
+                }
+            },
             growler: {
                 include: true,
                 id: 'growler',
@@ -140,16 +242,6 @@ define([
                         }
                     }
                 }
-            },
-            identify: {
-                include: true,
-                id: 'identify',
-                type: 'titlePane',
-                path: 'gis/dijit/Identify',
-                title: 'Identify',
-                open: false,
-                position: 3,
-                options: 'config/identify'
             },
             basemaps: {
                 include: true,
@@ -240,45 +332,6 @@ define([
                     })
                 }
             },
-            legend: {
-                include: true,
-                id: 'legend',
-                type: 'titlePane',
-                path: 'esri/dijit/Legend',
-                title: 'Legend',
-                open: false,
-                position: 0,
-                options: {
-                    map: true,
-                    legendLayerInfos: true
-                }
-            },
-            layerControl: {
-                include: true,
-                id: 'layerControl',
-                type: 'titlePane',
-                path: 'gis/dijit/LayerControl',
-                title: 'Layers',
-                open: false,
-                position: 0,
-                options: {
-                    map: true,
-                    layerControlLayerInfos: true,
-                    separated: true,
-                    vectorReorder: true,
-                    overlayReorder: true
-                }
-            },
-            bookmarks: {
-                include: true,
-                id: 'bookmarks',
-                type: 'titlePane',
-                path: 'gis/dijit/Bookmarks',
-                title: 'Bookmarks',
-                open: false,
-                position: 2,
-                options: 'config/bookmarks'
-            },
             find: {
                 include: true,
                 id: 'find',
@@ -302,22 +355,6 @@ define([
                 options: {
                     map: true,
                     mapClickMode: true
-                }
-            },
-            measure: {
-                include: true,
-                id: 'measurement',
-                type: 'titlePane',
-                canFloat: true,
-                path: 'gis/dijit/Measurement',
-                title: 'Measurement',
-                open: false,
-                position: 5,
-                options: {
-                    map: true,
-                    mapClickMode: true,
-                    defaultAreaUnit: units.SQUARE_MILES,
-                    defaultLengthUnit: units.MILES
                 }
             },
             print: {

--- a/viewer/js/config/viewer.js
+++ b/viewer/js/config/viewer.js
@@ -127,95 +127,24 @@ define([
                     // height
                     widgets: [
                         {
-                            id: 'identify',
-                            title: 'Identify',
-                            icon: '/js/gis/dijit/Identify/images/identify.png',
-                            group: 'group1'
-                        },
-                        {
                             id: 'legend',
                             title: 'Legend',
                             icon: null,
-                            group: 'group2'
-                        }, 
-                        {
-                            id: 'layerControl',
-                            title: 'Layers',
-                            icon: null,
-                            group: 'group2'
+                            group: 'group1'
                         }, 
                         {
                             id: 'bookmarks',
                             title: 'Bookmarks',
                             icon: null,
-                            group: 'group3'
+                            group: 'group1'
                         },
                         {
-                            id: 'measurement',
-                            title: 'Measure',
+                            id: 'help',
+                            title: 'Help',
                             open: false,
-                            group: 'group3'
+                            group: null
                         }
                     ]
-                }
-            },
-            identify: {
-                include: true,
-                id: 'identify',
-                type: 'gis/dijit/FloatingWidgetPanel',
-                srcNodeRef: 'cmvMenuNode',
-                path: 'gis/dijit/Identify',
-                title: 'Identify',
-                options: 'config/identify'
-            },
-            legend: {
-                include: true,
-                id: 'legend',
-                type: 'gis/dijit/FloatingWidgetPanel',
-                srcNodeRef: 'cmvMenuNode',
-                path: 'esri/dijit/Legend',
-                title: 'Legend',
-                options: {
-                    map: true,
-                    legendLayerInfos: true
-                }
-            }, 
-            layers: {
-                include: true,
-                id: 'layerControl',
-                type: 'gis/dijit/FloatingWidgetPanel',
-                srcNodeRef: 'cmvMenuNode',
-                path: 'gis/dijit/LayerControl',
-                title: 'Layers',
-                options: {
-                    map: true,
-                    layerControlLayerInfos: true,
-                    separated: true,
-                    vectorReorder: true,
-                    overlayReorder: true
-                }
-            }, 
-            bookmarks: {
-                include: true,
-                id: 'bookmarks',
-                type: 'gis/dijit/FloatingWidgetPanel',
-                srcNodeRef: 'cmvMenuNode',
-                path: 'gis/dijit/Bookmarks',
-                title: 'Bookmarks',
-                options: 'config/bookmarks'
-            },
-            measure: {
-                include: true,
-                id: 'measurement',
-                type: 'gis/dijit/FloatingWidgetPanel',
-                srcNodeRef: 'cmvMenuNode',
-                path: 'gis/dijit/Measurement',
-                title: 'Measurement',
-                options: {
-                    map: true,
-                    mapClickMode: true,
-                    defaultAreaUnit: units.SQUARE_MILES,
-                    defaultLengthUnit: units.MILES
                 }
             },
             growler: {
@@ -242,6 +171,16 @@ define([
                         }
                     }
                 }
+            },
+            identify: {
+                include: true,
+                id: 'identify',
+                type: 'titlePane',
+                path: 'gis/dijit/Identify',
+                title: 'Identify',
+                open: false,
+                position: 3,
+                options: 'config/identify'
             },
             basemaps: {
                 include: true,
@@ -332,6 +271,47 @@ define([
                     })
                 }
             },
+            legend: {
+                include: true,
+                id: 'legend',
+                type: 'gis/dijit/FloatingWidgetPanel',
+                srcNodeRef: 'cmvMenuNode',
+                path: 'esri/dijit/Legend',
+                title: 'Legend',
+                //open: false,
+                //position: 0,
+                options: {
+                    map: true,
+                    legendLayerInfos: true
+                }
+            }, 
+            layerControl: {
+                include: true,
+                id: 'layerControl',
+                type: 'titlePane',
+                path: 'gis/dijit/LayerControl',
+                title: 'Layers',
+                open: false,
+                position: 0,
+                options: {
+                    map: true,
+                    layerControlLayerInfos: true,
+                    separated: true,
+                    vectorReorder: true,
+                    overlayReorder: true
+                }
+            }, 
+            bookmarks: {
+                include: true,
+                id: 'bookmarks',
+                type: 'gis/dijit/FloatingWidgetPanel',
+                srcNodeRef: 'cmvMenuNode',
+                path: 'gis/dijit/Bookmarks',
+                title: 'Bookmarks',
+                //open: false,
+                //position: 2,
+                options: 'config/bookmarks'
+            },
             find: {
                 include: true,
                 id: 'find',
@@ -355,6 +335,22 @@ define([
                 options: {
                     map: true,
                     mapClickMode: true
+                }
+            },
+            measure: {
+                include: true,
+                id: 'measurement',
+                type: 'titlePane',
+                canFloat: true,
+                path: 'gis/dijit/Measurement',
+                title: 'Measurement',
+                open: false,
+                position: 5,
+                options: {
+                    map: true,
+                    mapClickMode: true,
+                    defaultAreaUnit: units.SQUARE_MILES,
+                    defaultLengthUnit: units.MILES
                 }
             },
             print: {
@@ -446,7 +442,6 @@ define([
                 title: 'Help',
                 options: {}
             }
-
         }
     };
 });

--- a/viewer/js/config/viewer.js
+++ b/viewer/js/config/viewer.js
@@ -278,13 +278,11 @@ define([
                 srcNodeRef: 'cmvMenuNode',
                 path: 'esri/dijit/Legend',
                 title: 'Legend',
-                //open: false,
-                //position: 0,
                 options: {
                     map: true,
                     legendLayerInfos: true
                 }
-            }, 
+            },
             layerControl: {
                 include: true,
                 id: 'layerControl',
@@ -300,7 +298,7 @@ define([
                     vectorReorder: true,
                     overlayReorder: true
                 }
-            }, 
+            },
             bookmarks: {
                 include: true,
                 id: 'bookmarks',
@@ -308,8 +306,6 @@ define([
                 srcNodeRef: 'cmvMenuNode',
                 path: 'gis/dijit/Bookmarks',
                 title: 'Bookmarks',
-                //open: false,
-                //position: 2,
                 options: 'config/bookmarks'
             },
             find: {
@@ -323,6 +319,7 @@ define([
                 position: 3,
                 options: 'config/find'
             },
+            
             draw: {
                 include: true,
                 id: 'draw',

--- a/viewer/js/config/viewer.js
+++ b/viewer/js/config/viewer.js
@@ -319,7 +319,6 @@ define([
                 position: 3,
                 options: 'config/find'
             },
-            
             draw: {
                 include: true,
                 id: 'draw',
@@ -334,6 +333,7 @@ define([
                     mapClickMode: true
                 }
             },
+
             measure: {
                 include: true,
                 id: 'measurement',

--- a/viewer/js/gis/dijit/CmvMenuWidget.js
+++ b/viewer/js/gis/dijit/CmvMenuWidget.js
@@ -1,0 +1,194 @@
+define([
+  'dijit/_TemplatedMixin',
+  'dijit/_WidgetBase',
+  'dijit/_WidgetsInTemplateMixin',
+  'dijit/registry',
+  'dojo/_base/array',
+  'dojo/_base/declare',
+  'dojo/_base/html',
+  'dojo/_base/lang',
+  'dojo/dom-class',
+  'dojo/on',
+  'dojo/query',
+  'dojo/text!./CmvMenuWidget/templates/template.html',
+
+  'xstyle/css!./CmvMenuWidget/css/style.css'
+],
+  function(
+  _TemplatedMixin,
+  _WidgetBase,
+  _WidgetsInTemplateMixin,
+  registry,
+array,
+  declare,
+  html,
+  lang,
+  domClass,
+  on,
+  query,
+  template
+) {
+    return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
+
+      widgetsInTemplate: true,
+      templateString: template,
+      baseClass: 'CmvMenu',
+      //the default height of the icon
+      iconHeight: 16,
+      //the default height of the widget
+      height: 20,
+      widgets: {},
+
+      postCreate: function() {
+        this.inherited(arguments);
+
+        if (this.position && this.position.height) {
+          this.height = this.position.height;
+        }
+
+      },
+
+      startup: function() {
+        this.inherited(arguments);
+        this._createMenuItems();
+      },
+
+      _createMenuItems: function() {
+        html.empty(this.containerNode);
+
+        var openMenuItem = null;
+        array.forEach(this.widgets, function(aWidgetConfig) {
+          var node = this._createMenuItem(aWidgetConfig);
+          if (aWidgetConfig.open === true) {
+            openMenuItem = node;
+          }
+        }, this);
+        // note that all this widgets might not be loaded yet so this may fail
+        /*
+        if (openMenuItem) {
+          this._onMenuClick(openMenuItem);
+        }
+        */
+      },
+
+      _createMenuItem: function(aWidgetConfig) {
+
+        var menuItemNode = html.create('div', {
+          'class': 'menu-item',
+          'data-cmvmenu-id': aWidgetConfig.id
+        }, this.containerNode);
+
+        if(aWidgetConfig.icon) {
+          html.create('div', {
+            title: aWidgetConfig.title,
+            'class': 'menu-item-icon',
+            'style': {
+              'line-height': this.height + 'px',
+              width: this.iconHeight + 'px',
+              height: this.iconHeight + 'px',
+              'background-image': 'url(' + aWidgetConfig.icon + ')',
+              'background-repeat': 'no-repeat',
+              'background-size': this.iconHeight + 'px ' + this.iconHeight + 'px',
+              'margin-top': ((this.height - this.iconHeight) / 2) + 'px'
+            }
+          }, menuItemNode);
+        }
+        html.create('div', {
+          'class': 'menu-item-text',
+          'style': {
+            'line-height': this.height + 'px'
+          },
+          innerHTML: aWidgetConfig.title
+        }, menuItemNode);
+
+        on(menuItemNode, 'click', lang.hitch(this, function () {
+          this._onMenuClick(aWidgetConfig);
+        }));
+
+        //menuItemNode.config = aWidgetConfig;
+
+        return menuItemNode;
+      },
+
+      _onMenuClick: function(aWidgetConfig) {
+        var parentWidget = registry.byId(aWidgetConfig.id + '_parent');
+        if(parentWidget) {
+          if(parentWidget.open) {
+            this._closeMenuItem(aWidgetConfig.id);
+            this._closeWidget(aWidgetConfig.id);
+          }
+          else {
+            // close others 
+            array.forEach(this.widgets, function(aWidgetConfigToClose) {
+              if(aWidgetConfigToClose.id !== aWidgetConfig.id && aWidgetConfig.group && aWidgetConfigToClose.group == aWidgetConfig.group)
+              //if(aWidgetConfigToClose.id != aWidgetConfig.id)
+              {
+                this._closeMenuItem(aWidgetConfigToClose.id);
+                this._closeWidget(aWidgetConfigToClose.id);
+              }
+            }, this);
+            // open this one
+            this._openMenuItem(aWidgetConfig.id); 
+            this._openWidget(aWidgetConfig.id);
+          }
+        }
+      },
+
+      _openWidget: function(id) {
+        var widget = registry.byId(id + '_widget');
+        if(widget) {
+          var parentWidget = widget.parentWidget;
+          if(parentWidget) {
+
+            on(parentWidget, 'toggle', lang.hitch(this, '_toggleMenuItem', id));
+
+            parentWidget.show();
+          }
+        }
+      },
+      _closeWidget: function(id) {
+        var widget = registry.byId(id + '_widget');
+        if(widget) {
+          var parentWidget = widget.parentWidget;
+          if(parentWidget) {
+            parentWidget.hide();
+          }
+        }
+      },
+
+      _getMenuItemById: function(id) {
+        var node = query('.menu-item[data-cmvmenu-id="' + id + '"]', this.domNode);
+        if (node.length === 0) {
+          return;
+        }
+        return node[0];
+      },
+
+      _toggleMenuItem: function(id, isOpen) {
+        if(isOpen) {
+          this._closeMenuItem(id);
+        }
+        else {
+          this._openMenuItem(id);
+        }
+        /*
+        var node = this._getMenuItemById(id);
+        if(parentWidget.open) {
+          this._closeMenuItem(node);
+        }
+        else {
+          this._openMenuItem(node);
+        }
+        */
+      },
+      _openMenuItem: function(id) {
+        var node = this._getMenuItemById(id);
+        domClass.add(node, 'open');
+      },
+      _closeMenuItem: function(id) {
+        var node = this._getMenuItemById(id);
+        domClass.remove(node, 'open');
+      }
+
+    });
+});

--- a/viewer/js/gis/dijit/CmvMenuWidget.js
+++ b/viewer/js/gis/dijit/CmvMenuWidget.js
@@ -32,9 +32,6 @@ define([
       startup: function() {
         this.inherited(arguments);
 
-        // do not empty the container node because their may be other widgets in there
-        //html.empty(this.containerNode);
-
         var openMenuItem = null;
         array.forEach(this.widgets, function(aWidgetConfig) {
           var node = this._createMenuItem(aWidgetConfig);

--- a/viewer/js/gis/dijit/CmvMenuWidget.js
+++ b/viewer/js/gis/dijit/CmvMenuWidget.js
@@ -8,30 +8,18 @@ define([
   'dojo/_base/declare',
   'dojo/_base/html',
   'dojo/_base/lang',
-  'dojo/aspect',
   'dojo/dom-class',
   'dojo/on',
+  'dojo/aspect',
   'dojo/text!./CmvMenuWidget/templates/template.html',
 
   'xstyle/css!./CmvMenuWidget/css/style.css'
 ],
-  function(
-  _TemplatedMixin,
-  _WidgetBase,
-  _WidgetsInTemplateMixin,
-  registry,
-
-  array,
-  declare,
-  html,
-  lang,
-  aspect,
-  domClass,
-  on,
-  template
-) {
+  function(_TemplatedMixin, _WidgetBase, _WidgetsInTemplateMixin, registry, array, declare, html, lang, domClass, on, aspect, template) {
     return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
 
+      // NOTE: CmvMenuWidget requires that the widget implement the open and toggleable properties, and also the toggle method
+      
       widgetsInTemplate: true,
       templateString: template,
       baseClass: 'CmvMenu',
@@ -94,7 +82,6 @@ define([
         aWidgetConfig.menuItem = menuItemNode;
 
         on(menuItemNode, 'click', lang.hitch(this, '_onMenuClick', aWidgetConfig));
-
       },
 
       _onMenuClick: function(aWidgetConfig) {
@@ -159,21 +146,20 @@ define([
       },
 
       _openWidget: function(aWidgetConfig) {
-        // toggle will also capture if the user toggles the widget using the x-button or some unknown means
-        aspect.after(aWidgetConfig.widget.parentWidget, 'toggle', lang.hitch(this, '_toggleMenuItem', aWidgetConfig.menuItem), true);
         if(this._findAndStoreParentWidget(aWidgetConfig) === true) {
-          aWidgetConfig.widget.parentWidget.show();
+          aspect.after(aWidgetConfig.widget.parentWidget, 'toggle', lang.hitch(this, '_onToggle', aWidgetConfig.menuItem), true);
+          aWidgetConfig.widget.parentWidget.toggle(true);
         }
       },
 
       _closeWidget: function(aWidgetConfig) {
         if(this._findAndStoreParentWidget(aWidgetConfig) === true) {
-          aWidgetConfig.widget.parentWidget.hide();
+          aWidgetConfig.widget.parentWidget.toggle(false);
         }
       },
 
-      _toggleMenuItem: function(aMenuItem, isOpen) {
-        if(isOpen) {
+      _onToggle: function(aMenuItem, open) {
+        if(open) {
           domClass.add(aMenuItem, 'open');
         }
         else {

--- a/viewer/js/gis/dijit/CmvMenuWidget/css/style.css
+++ b/viewer/js/gis/dijit/CmvMenuWidget/css/style.css
@@ -1,0 +1,30 @@
+.CmvMenu {
+  font-size: 16px;
+}
+
+.CmvMenu .menu-item {
+    float: left;
+    cursor: pointer;
+    margin-right: 10px;
+    opacity: 0.8;
+    padding-top: 2px;
+}
+.CmvMenu .open {
+  border-top: 2px solid #fff;
+  padding-top: 0;
+  opacity: 1;
+}
+
+.CmvMenu .menu-item:hover {
+  border-top: 2px solid #fff;
+  padding-top: 0;
+}
+
+.CmvMenu .menu-item .menu-item-text {
+  float: left;
+  vertical-align: middle;
+}
+.CmvMenu .menu-item .menu-item-icon {
+  float: left;
+  vertical-align: middle;
+}

--- a/viewer/js/gis/dijit/CmvMenuWidget/templates/template.html
+++ b/viewer/js/gis/dijit/CmvMenuWidget/templates/template.html
@@ -1,0 +1,5 @@
+<div class="${baseClass}">
+    <div>
+        <div class="containerNode" data-dojo-attach-point="containerNode"></div>
+    </div>
+</div>

--- a/viewer/js/gis/dijit/CmvMenuWidget/templates/template.html
+++ b/viewer/js/gis/dijit/CmvMenuWidget/templates/template.html
@@ -1,5 +1,5 @@
 <div class="${baseClass}">
-    <div>
+    <div style="width:100%; text-align: center;">
         <div class="containerNode" data-dojo-attach-point="containerNode"></div>
     </div>
 </div>

--- a/viewer/js/gis/dijit/FloatingWidgetDialog.js
+++ b/viewer/js/gis/dijit/FloatingWidgetDialog.js
@@ -10,9 +10,9 @@ define([
 		draggable: true,
 		toggleable: true,
 		'class': 'floatingWidget',
-		close: function() {
+		close: function () {
 			this.hide();
-		}
+		},
 		focus: function () {},
 		startup: function() {
 			this.inherited(arguments);

--- a/viewer/js/gis/dijit/FloatingWidgetDialog.js
+++ b/viewer/js/gis/dijit/FloatingWidgetDialog.js
@@ -10,6 +10,9 @@ define([
 		draggable: true,
 		toggleable: true,
 		'class': 'floatingWidget',
+		close: function() {
+			this.hide();
+		}
 		focus: function () {},
 		startup: function() {
 			this.inherited(arguments);
@@ -21,7 +24,7 @@ define([
 			if(arguments.length < 2) {
 				doToggle = true;
 			}
-			// we do not execute the toggle if it was already done by this widget
+			// we do not execute the toggle if we are handling an event that was executed by the  widget
 			if(doToggle) {
 				if(open) {
 					this.show();

--- a/viewer/js/gis/dijit/FloatingWidgetDialog.js
+++ b/viewer/js/gis/dijit/FloatingWidgetDialog.js
@@ -1,15 +1,35 @@
 define([
+	'dijit/Dialog',
 	'dojo/_base/declare',
-	'dijit/Dialog'
-], function (declare, Dialog) {
+	'dojo/_base/lang',
+	'dojo/on'
+], function (Dialog, declare,  lang, on) {
 	return declare([Dialog], {
 		declaredClass: 'gis.dijit.FloatingWidget',
 		title: 'Floating Widget',
 		draggable: true,
+		toggleable: true,
 		'class': 'floatingWidget',
-		close: function () {
-			this.hide();
+		focus: function () {},
+		startup: function() {
+			this.inherited(arguments);
+			this.own(on(this, 'hide', lang.hitch(this, 'toggle', false, false)));
+			this.own(on(this, 'show', lang.hitch(this, 'toggle', true, false)));
 		},
-		focus: function () {}
+		toggle: function(open, doToggle) {
+			// default doToggle to true
+			if(arguments.length < 2) {
+				doToggle = true;
+			}
+			// we do not execute the toggle if it was already done by this widget
+			if(doToggle) {
+				if(open) {
+					this.show();
+				}
+				else {
+					this.hide();
+				}
+			}
+		}
 	});
 });

--- a/viewer/js/gis/dijit/FloatingWidgetPanel.js
+++ b/viewer/js/gis/dijit/FloatingWidgetPanel.js
@@ -1,0 +1,34 @@
+define([
+  'dijit/_TemplatedMixin',
+  'dijit/_WidgetBase',
+
+  'dojo/_base/declare',
+  'dojo/dom-style',
+  'dojo/text!./FloatingWidgetPanel/templates/template.html',
+
+  'xstyle/css!./FloatingWidgetPanel/css/style.css'
+], function (
+  _TemplatedMixin,
+  _WidgetBase,
+
+  declare,
+  domStyle,
+  template
+) {
+    return declare([_WidgetBase, _TemplatedMixin], {
+      open: false,
+      baseClass: 'FloatingWigetPanel',
+      toggleable: true,
+      templateString: template,
+      show: function() {
+        this.toggle(true);
+      },
+      hide: function() {
+        this.toggle(false);
+      },
+      toggle: function(isOpen) {
+        this.open = isOpen;
+        domStyle.set(this.domNode, 'display', isOpen === true ? 'block' : 'none');
+      }
+    });
+  });

--- a/viewer/js/gis/dijit/FloatingWidgetPanel.js
+++ b/viewer/js/gis/dijit/FloatingWidgetPanel.js
@@ -7,28 +7,31 @@ define([
   'dojo/text!./FloatingWidgetPanel/templates/template.html',
 
   'xstyle/css!./FloatingWidgetPanel/css/style.css'
-], function (
-  _TemplatedMixin,
-  _WidgetBase,
+  ], function (
+    _TemplatedMixin,
+    _WidgetBase,
 
-  declare,
-  domStyle,
-  template
-) {
+    declare,
+    domStyle,
+    template
+
+    ) {
     return declare([_WidgetBase, _TemplatedMixin], {
-      open: false,
+
       baseClass: 'FloatingWigetPanel',
-      toggleable: true,
       templateString: template,
-      show: function() {
-        this.toggle(true);
-      },
-      hide: function() {
-        this.toggle(false);
-      },
-      toggle: function(isOpen) {
-        this.open = isOpen;
-        domStyle.set(this.domNode, 'display', isOpen === true ? 'block' : 'none');
+
+      open: false,
+      toggleable: true,
+      toggle: function(show) {
+        this.open = show;
+        if(show === true) {
+          domStyle.set(this.domNode, 'display', 'block');
+        }
+        else {
+          domStyle.set(this.domNode, 'display', 'none');
+        }
       }
-    });
-  });
+    }
+  );
+});

--- a/viewer/js/gis/dijit/FloatingWidgetPanel/css/style.css
+++ b/viewer/js/gis/dijit/FloatingWidgetPanel/css/style.css
@@ -1,12 +1,4 @@
 .FloatingWigetPanelContainer {
-  position: absolute;
-  top: 70px;
-  right: 10px;
-  left: auto;
-  bottom: 10px;
-  width: auto;
-  height: auto;
-  z-index: 1;
   overflow: auto;
 }
 

--- a/viewer/js/gis/dijit/FloatingWidgetPanel/css/style.css
+++ b/viewer/js/gis/dijit/FloatingWidgetPanel/css/style.css
@@ -1,0 +1,18 @@
+.FloatingWigetPanelContainer {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  left: auto;
+  bottom: 10px;
+  width: auto;
+  height: auto;
+  z-index: 1;
+  overflow: auto;
+}
+
+.FloatingWigetPanel {
+  border: solid 1px #000;
+  background-color: #fff;
+  padding: 20px;
+  display: none;
+}

--- a/viewer/js/gis/dijit/FloatingWidgetPanel/css/style.css
+++ b/viewer/js/gis/dijit/FloatingWidgetPanel/css/style.css
@@ -1,6 +1,6 @@
 .FloatingWigetPanelContainer {
   position: absolute;
-  top: 10px;
+  top: 70px;
   right: 10px;
   left: auto;
   bottom: 10px;

--- a/viewer/js/gis/dijit/FloatingWidgetPanel/templates/template.html
+++ b/viewer/js/gis/dijit/FloatingWidgetPanel/templates/template.html
@@ -1,0 +1,3 @@
+<div class='${baseClass}'>
+	<span data-dojo-attach-point='containerNode'></span>
+</div>

--- a/viewer/js/viewer/Controller.js
+++ b/viewer/js/viewer/Controller.js
@@ -4,6 +4,7 @@ define([
 	'dojo/dom-style',
 	'dojo/dom-geometry',
 	'dojo/dom-class',
+	'dojo/dom-construct',
 	'dojo/on',
 	'dojo/_base/array',
 	'dijit/layout/BorderContainer',
@@ -12,6 +13,7 @@ define([
 	'dojo/_base/lang',
 	'dojo/text!./templates/mapOverlay.html',
 	'gis/dijit/FloatingWidgetDialog',
+	'gis/dijit/FloatingWidgetPanel',
 	'put-selector',
 	'dojo/aspect',
 	'dojo/has',
@@ -19,7 +21,7 @@ define([
 	'esri/dijit/PopupMobile',
 	'dijit/Menu',
 	'esri/IdentityManager'
-], function (Map, dom, domStyle, domGeom, domClass, on, array, BorderContainer, ContentPane, FloatingTitlePane, lang, mapOverlay, FloatingWidgetDialog, put, aspect, has, topic, PopupMobile, Menu) {
+], function (Map, dom, domStyle, domGeom, domClass, domConstruct, on, array, BorderContainer, ContentPane, FloatingTitlePane, lang, mapOverlay, FloatingWidgetDialog, FloatingWidgetPanel, put, aspect, has, topic, PopupMobile, Menu) {
 
 	return {
 		legendLayerInfos: [],
@@ -430,6 +432,17 @@ define([
 			fw.startup();
 			return fw;
 		},
+		_createFloatingPanelWidget: function(parentId, title, srcNodeRef) {
+			if(!srcNodeRef) {
+	        	 srcNodeRef = domConstruct.create('div', {}, this.map.root, 'first');
+	    	}
+			var pnl = new FloatingWidgetPanel({
+				id: parentId,
+				title: title
+			});
+			pnl.placeAt(srcNodeRef);
+			return pnl;
+		},
 		_createContentPaneWidget: function (parentId, title, className, region, placeAt) {
 			var cp, options = {
 					title: title,
@@ -456,7 +469,7 @@ define([
 			var parentId, pnl;
 
 			// only proceed for valid widget types
-			var widgetTypes = ['titlePane', 'contentPane', 'floating', 'domNode', 'invisible', 'map'];
+			var widgetTypes = ['titlePane', 'contentPane', 'floating', 'gis/dijit/FloatingWidgetPanel', 'domNode', 'invisible', 'map'];
 			if (array.indexOf(widgetTypes, widgetConfig.type) < 0) {
 				this.handleError({
 					source: 'Controller',
@@ -464,9 +477,9 @@ define([
 				});
 				return;
 			}
-
+			
 			// build a titlePane or floating widget as the parent
-			if ((widgetConfig.type === 'titlePane' || widgetConfig.type === 'contentPane' || widgetConfig.type === 'floating') && (widgetConfig.id && widgetConfig.id.length > 0)) {
+			if ((widgetConfig.type === 'titlePane' || widgetConfig.type === 'contentPane' || widgetConfig.type === 'floating' || widgetConfig.type === 'gis/dijit/FloatingWidgetPanel') && (widgetConfig.id && widgetConfig.id.length > 0)) {
 				parentId = widgetConfig.id + '_parent';
 				if (widgetConfig.type === 'titlePane') {
 					pnl = this._createTitlePaneWidget(parentId, widgetConfig.title, position, widgetConfig.open, widgetConfig.canFloat, widgetConfig.placeAt);
@@ -474,6 +487,8 @@ define([
 					pnl = this._createContentPaneWidget(parentId, widgetConfig.title, widgetConfig.className, widgetConfig.region, widgetConfig.placeAt);
 				} else if (widgetConfig.type === 'floating') {
 					pnl = this._createFloatingWidget(parentId, widgetConfig.title);
+				} else if (widgetConfig.type === 'gis/dijit/FloatingWidgetPanel') {
+					pnl = this._createFloatingPanelWidget(parentId, widgetConfig.title, widgetConfig.srcNodeRef);
 				}
 				widgetConfig.parentWidget = pnl;
 			}
@@ -523,7 +538,7 @@ define([
 
 			// create the widget
 			var pnl = options.parentWidget;
-			if ((widgetConfig.type === 'titlePane' || widgetConfig.type === 'contentPane' || widgetConfig.type === 'floating')) {
+			if ((widgetConfig.type === 'titlePane' || widgetConfig.type === 'contentPane' || widgetConfig.type === 'floating' || widgetConfig.type === 'gis/dijit/FloatingWidgetPanel')) {
 				this[widgetConfig.id] = new WidgetClass(options, put('div')).placeAt(pnl.containerNode);
 			} else if (widgetConfig.type === 'domNode') {
 				this[widgetConfig.id] = new WidgetClass(options, widgetConfig.srcNodeRef);

--- a/viewer/js/viewer/Controller.js
+++ b/viewer/js/viewer/Controller.js
@@ -433,13 +433,16 @@ define([
 			return fw;
 		},
 		_createFloatingPanelWidget: function(parentId, title, srcNodeRef) {
+			var options = {
+				title: title
+			};
+			if (parentId) {
+				options.id = parentId;
+			}
 			if(!srcNodeRef) {
 	        	 srcNodeRef = domConstruct.create('div', {}, this.map.root, 'first');
 	    	}
-			var pnl = new FloatingWidgetPanel({
-				id: parentId,
-				title: title
-			});
+			var pnl = new FloatingWidgetPanel(options);
 			pnl.placeAt(srcNodeRef);
 			return pnl;
 		},

--- a/viewer/js/viewer/Controller.js
+++ b/viewer/js/viewer/Controller.js
@@ -480,7 +480,7 @@ define([
 				});
 				return;
 			}
-			
+
 			// build a titlePane or floating widget as the parent
 			if ((widgetConfig.type === 'titlePane' || widgetConfig.type === 'contentPane' || widgetConfig.type === 'floating' || widgetConfig.type === 'gis/dijit/FloatingWidgetPanel') && (widgetConfig.id && widgetConfig.id.length > 0)) {
 				parentId = widgetConfig.id + '_parent';

--- a/viewer/js/viewer/templates/mapOverlay.html
+++ b/viewer/js/viewer/templates/mapOverlay.html
@@ -20,3 +20,4 @@
     <div id="geocoderButton">
     </div>
 </div>
+<div id="cmvMenuNode" class="FloatingWigetPanelContainer"></div>

--- a/viewer/js/viewer/templates/mapOverlay.html
+++ b/viewer/js/viewer/templates/mapOverlay.html
@@ -20,4 +20,4 @@
     <div id="geocoderButton">
     </div>
 </div>
-<div id="cmvMenuNode" class="FloatingWigetPanelContainer"></div>
+<div id="cmvMenuNode" style="position:absolute;top:70px;right:10px;bottom:10px;z-index:40;" class="FloatingWigetPanelContainer"></div>


### PR DESCRIPTION
This is a PR that probably requires significant discussion. 

I've create a horizontal menu in the applinks section. The menu controls widgets that have been added via the config as usual. Menu items can be "grouped", so only one widget from the group is shown at a time. Menu items can optionally have icons. The menu height and the icon height are optional config items.

The menu can control any widget that is in a "toggleable" container. For my needs, I created a new type of container called FloatingWidgetPanel, that does not derive from dijit/Dialog. The FloatingWidgetPanels are placed in a sort of StackPanel, so that if more than one widget is shown, they are stacked. 

To demonstrate the functionality, I added the Legend and Bookmarks to the menu. To demonstrate that the menu can also handle FloatingDialogs, I added the existing Help to the menu. I made modifications to the FloatingWidgetDialog so Help could work with the menu. 

Down the road, I'd like the menu to be more responsive. So, as the window shrinks, only the icons are shown. And, as the window shrinks to phone size, the menu docks to the bottom. I also see that there is a collision with the Geocoder widget, so perhaps the geocoder could become a Menu widget at small screen sized. The FloatingWidgetPanel should probably become more responsive, too. 