### PR TITLE
Config Mixin

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -54,16 +54,9 @@
         <![endif]-->
         <script type="text/javascript" src="//js.arcgis.com/3.13compact/"></script>
         <script type="text/javascript">
-            // get the config file from the url if present
-            var file = 'config/viewer', s = window.location.search, q = s.match(/config=([^&]*)/i);
-            if (q && q.length > 0) {
-                file = q[1];
-                if(file.indexOf('/') < 0) {
-                    file = 'config/' + file;
-                }
-            }
-            require(['viewer/Controller', file], function(Controller, config){
-                Controller.startup(config);
+            require(['viewer/Controller'], function(Controller){
+                var controller = new Controller();
+                controller.startup();
             });
         </script>
     </body>

--- a/viewer/js/viewer/Controller.js
+++ b/viewer/js/viewer/Controller.js
@@ -1,4 +1,6 @@
 define([
+	'./core/_ConfigMixin',
+	'dojo/_base/declare',
 	'esri/map',
 	'dojo/dom',
 	'dojo/dom-style',
@@ -19,9 +21,9 @@ define([
 	'esri/dijit/PopupMobile',
 	'dijit/Menu',
 	'esri/IdentityManager'
-], function (Map, dom, domStyle, domGeom, domClass, on, array, BorderContainer, ContentPane, FloatingTitlePane, lang, mapOverlay, FloatingWidgetDialog, put, aspect, has, topic, PopupMobile, Menu) {
+], function (_ConfigMixin, declare, Map, dom, domStyle, domGeom, domClass, on, array, BorderContainer, ContentPane, FloatingTitlePane, lang, mapOverlay, FloatingWidgetDialog, put, aspect, has, topic, PopupMobile, Menu) {
 
-	return {
+	return declare([_ConfigMixin], {
 		legendLayerInfos: [],
 		editorLayerInfos: [],
 		identifyLayerInfos: [],
@@ -41,7 +43,17 @@ define([
 			}
 		},
 		collapseButtons: {},
-		startup: function (config) {
+		startup: function () {
+			this.inherited(arguments);
+
+			// from ConfigMixin
+			this.initConfigAsync().then(
+				lang.hitch(this, 'initConfigSuccess'),
+				lang.hitch(this, 'initConfigError')
+			);
+		},
+
+		initConfigSuccess: function(config) {
 			this.config = config;
 			this.mapClickMode = {
 				current: config.defaultMapClickMode,
@@ -66,6 +78,14 @@ define([
 				window.app = this; //dev only
 			}
 		},
+
+		initConfigError: function(err) {
+			this.handleError({
+				source: 'Controller',
+				error: err
+			});
+		},
+
 		// add topics for subscribing and publishing
 		addTopics: function () {
 			// toggle a sidebar pane
@@ -538,7 +558,7 @@ define([
 		},
 		//centralized error handler
 		handleError: function (options) {
-			if (this.config.isDebug) {
+			if (this.config && this.config.isDebug) {
 				if (typeof (console) === 'object') {
 					for (var option in options) {
 						if (options.hasOwnProperty(option)) {
@@ -551,5 +571,5 @@ define([
 				return;
 			}
 		}
-	};
+	});
 });

--- a/viewer/js/viewer/core/_ConfigMixin.js
+++ b/viewer/js/viewer/core/_ConfigMixin.js
@@ -1,10 +1,8 @@
 define([
 	'dojo/_base/declare',
-	'dojo/_base/lang',
-	'dojo/Deferred',
-	'dojo/on'
+	'dojo/Deferred'
 ], function (
-	declare, lang, Deferred, on
+	declare, Deferred
 ) {
 
 	return declare(null, {
@@ -19,16 +17,10 @@ define([
 					file = 'config/' + file;
 				}
 			}
-			on(require, 'error', lang.hitch(this, '_requireError', file, returnDeferred));
 			require([file], function(config){
 				returnDeferred.resolve(config);
 			});
-
 			return returnDeferred;
-		},
-
-		_requireError: function(file, returnDeferred) {
-			returnDeferred.reject('unable to load config: ' + file);
 		}
 
 	});

--- a/viewer/js/viewer/core/_ConfigMixin.js
+++ b/viewer/js/viewer/core/_ConfigMixin.js
@@ -1,0 +1,37 @@
+define([
+    'dojo/_base/declare',
+    'dojo/_base/lang',
+    'dojo/Deferred',
+    'dojo/on'
+], function (
+    declare, lang, Deferred, on
+) {
+
+	return declare(null, {
+	 
+		initConfigAsync: function() {
+			var returnDeferred = new Deferred();
+            // get the config file from the url if present
+            var file = 'config/viewer', s = window.location.search, q = s.match(/config=([^&]*)/i);
+            if (q && q.length > 0) {
+                file = q[1];
+                if(file.indexOf('/') < 0) {
+                    file = 'config/' + file;
+                }
+            }
+            on(require, 'error', lang.hitch(this, '_requireError', file, returnDeferred));
+            require([file], function(config){
+                returnDeferred.resolve(config);
+            });
+
+			return returnDeferred;
+		},
+
+        _requireError: function(file, returnDeferred) {
+            returnDeferred.reject('unable to load config: ' + file);
+        }
+
+ 	});
+
+
+});

--- a/viewer/js/viewer/core/_ConfigMixin.js
+++ b/viewer/js/viewer/core/_ConfigMixin.js
@@ -1,37 +1,36 @@
 define([
-    'dojo/_base/declare',
-    'dojo/_base/lang',
-    'dojo/Deferred',
-    'dojo/on'
+	'dojo/_base/declare',
+	'dojo/_base/lang',
+	'dojo/Deferred',
+	'dojo/on'
 ], function (
-    declare, lang, Deferred, on
+	declare, lang, Deferred, on
 ) {
 
 	return declare(null, {
-	 
+
 		initConfigAsync: function() {
 			var returnDeferred = new Deferred();
-            // get the config file from the url if present
-            var file = 'config/viewer', s = window.location.search, q = s.match(/config=([^&]*)/i);
-            if (q && q.length > 0) {
-                file = q[1];
-                if(file.indexOf('/') < 0) {
-                    file = 'config/' + file;
-                }
-            }
-            on(require, 'error', lang.hitch(this, '_requireError', file, returnDeferred));
-            require([file], function(config){
-                returnDeferred.resolve(config);
-            });
+			// get the config file from the url if present
+			var file = 'config/viewer', s = window.location.search, q = s.match(/config=([^&]*)/i);
+			if (q && q.length > 0) {
+				file = q[1];
+				if(file.indexOf('/') < 0) {
+					file = 'config/' + file;
+				}
+			}
+			on(require, 'error', lang.hitch(this, '_requireError', file, returnDeferred));
+			require([file], function(config){
+				returnDeferred.resolve(config);
+			});
 
 			return returnDeferred;
 		},
 
-        _requireError: function(file, returnDeferred) {
-            returnDeferred.reject('unable to load config: ' + file);
-        }
+		_requireError: function(file, returnDeferred) {
+			returnDeferred.reject('unable to load config: ' + file);
+		}
 
- 	});
-
+	});
 
 });


### PR DESCRIPTION
This is a small PR to move the config loading logic into a Mixin. This should make it easier to override the default behaviour of loading the config from a single file. By providing a custom mixin, one can easily load a config from a database, from a different URL, or by some other method. And, this can be done without modifying the core CMV code.

This does not address when a separate widget config filename is embedded in the config file itself. That will still perform a simple "require" for the widgetConfig.options.