### PR TITLE
Add menu to Layer Controller sub-layers

### DIFF
--- a/viewer/js/gis/dijit/LayerControl.js
+++ b/viewer/js/gis/dijit/LayerControl.js
@@ -157,7 +157,8 @@ define([
                     noTransparency: null,
                     swipe: null,
                     expanded: false,
-                    sublayers: true
+                    sublayers: true,
+                    menu: this.subLayerMenu[layerInfo.type]
                 }, layerInfo.controlOptions)
             });
             layerControl.startup();

--- a/viewer/js/gis/dijit/LayerControl.js
+++ b/viewer/js/gis/dijit/LayerControl.js
@@ -50,6 +50,7 @@ define([
         noLegend: null,
         noZoom: null,
         noTransparency: null,
+        subLayerMenu: {},
         swipe: null,
         swiperButtonStyle: 'position:absolute;top:20px;left:120px;z-index:50;',
         // ^args

--- a/viewer/js/gis/dijit/LayerControl/controls/_DynamicSublayer.js
+++ b/viewer/js/gis/dijit/LayerControl/controls/_DynamicSublayer.js
@@ -8,25 +8,31 @@ define([
     'dojo/dom-attr',
     'dojo/fx',
     'dojo/html',
+    'dijit/Menu',
+    'dijit/MenuItem',
+    'dojo/topic',
     'dijit/_WidgetBase',
     'dijit/_TemplatedMixin',
     'dojo/text!./templates/Sublayer.html',
     'dojo/i18n!./../nls/resource'
 ], function (
-    declare,
-    lang,
-    array,
-    on,
-    domClass,
-    domStyle,
-    domAttr,
-    fx,
-    html,
-    WidgetBase,
-    TemplatedMixin,
-    sublayerTemplate,
-    i18n
-) {
+        declare,
+        lang,
+        array,
+        on,
+        domClass,
+        domStyle,
+        domAttr,
+        fx,
+        html,
+        Menu,
+        MenuItem,
+        topic,
+        WidgetBase,
+        TemplatedMixin,
+        sublayerTemplate,
+        i18n
+        ) {
     var _DynamicSublayer = declare([WidgetBase, TemplatedMixin], {
         control: null,
         sublayerInfo: null,
@@ -61,13 +67,35 @@ define([
                 this._checkboxScaleRange();
                 this.control.layer.getMap().on('zoom-end', lang.hitch(this, '_checkboxScaleRange'));
             }
+            //set up menu
+            if (this.control.controlOptions.menu && 
+                    this.control.controlOptions.menu.length) {
+                domClass.add(this.labelNode, 'menuLink');
+                this.menu = new Menu({
+                    contextMenuForWindow: false,
+                    targetNodeIds: [this.labelNode],
+                    leftClickToOpen: true
+                });
+                array.forEach(this.control.controlOptions.menu, lang.hitch(this, '_addMenuItem'));
+                this.menu.startup();
+            }
+        },
+        _addMenuItem: function (menuItem) {
+            this.menu.addChild(new MenuItem(lang.mixin(menuItem, {
+                onClick: lang.hitch(this, function () {
+                    topic.publish('LayerControl/' + menuItem.topic, {
+                        layer: this.control.layer,
+                        subLayer: this.sublayerInfo
+                    });
+                })
+            })));
         },
         // add on event to expandClickNode
         _expandClick: function () {
             var i = this.icons;
             this._expandClickHandler = on(this.expandClickNode, 'click', lang.hitch(this, function () {
                 var expandNode = this.expandNode,
-                    iconNode = this.expandIconNode;
+                        iconNode = this.expandIconNode;
                 if (domStyle.get(expandNode, 'display') === 'none') {
                     fx.wipeIn({
                         node: expandNode,
@@ -98,9 +126,9 @@ define([
         // check scales and add/remove disabled classes from checkbox
         _checkboxScaleRange: function () {
             var node = this.checkNode,
-                scale = this.control.layer.getMap().getScale(),
-                min = this.sublayerInfo.minScale,
-                max = this.sublayerInfo.maxScale;
+                    scale = this.control.layer.getMap().getScale(),
+                    min = this.sublayerInfo.minScale,
+                    max = this.sublayerInfo.maxScale;
             domClass.remove(node, 'layerControlCheckIconOutScale');
             if ((min !== 0 && scale > min) || (max !== 0 && scale < max)) {
                 domClass.add(node, 'layerControlCheckIconOutScale');

--- a/viewer/js/gis/dijit/LayerControl/css/LayerControl.css
+++ b/viewer/js/gis/dijit/LayerControl/css/LayerControl.css
@@ -132,3 +132,14 @@
 .layerControlDijit .esriLegendServiceLabel {
     display: none;
 }
+
+.layerControlDijit .menuLink {
+    color: #369;
+    text-decoration: none;
+}
+
+.layerControlDijit .menuLink:hover {
+    color: #5196DB;
+    text-decoration: underline;
+    cursor: pointer;
+}


### PR DESCRIPTION
Just wanted to start a discussion on adding extensible menus to the sublayers in the layer control, starting with the dynamic type. 

I set this up so a user would pass a subLayerMenu option to the layercontroller and add menu items to each control by type. This property could be overridden by the `layerControlLayerInfos` property on the layer.

```JavaScript
                 subLayerMenu: {
                    dynamic: [{
                        label: 'Query Layer...',
                        iconClass: 'fa fa-search fa-fw',
                        topic: 'queryLayer'
                    }, {
                        label: 'Open Attribute Table',
                        topic: 'openTable',
                        iconClass: 'fa fa-table fa-fw'
                       }]
                },
```

On the menu click, the layer controller publishes a topic, `'LayerControl/topicName'` which passes the layer and the subLayer to any widgets subscribed to that topic.