### PR TITLE
add support for hiding operational layers in the legend 

### DIFF
--- a/viewer/js/config/viewer.js
+++ b/viewer/js/config/viewer.js
@@ -106,7 +106,8 @@ define([
                 id: 'DamageAssessment',
                 opacity: 1.0,
                 visible: true,
-                imageParameters: imageParameters
+                imageParameters: imageParameters,
+                showInLegend: false
             },
             layerControlLayerInfos: {
                 swipe: true,

--- a/viewer/js/config/viewer.js
+++ b/viewer/js/config/viewer.js
@@ -117,8 +117,7 @@ define([
                 id: 'DamageAssessment',
                 opacity: 1.0,
                 visible: true,
-                imageParameters: imageParameters,
-                showInLegend: false
+                imageParameters: imageParameters
             },
             legendLayerInfos: {
                 exclude: true

--- a/viewer/js/config/viewer.js
+++ b/viewer/js/config/viewer.js
@@ -73,6 +73,12 @@ define([
             },
             editorLayerInfos: {
                 disableGeometryUpdate: false
+            },
+            legendLayerInfos: {
+                exclude: false,
+                layerInfo: {
+                    title: 'My layer'
+                }
             }
   }, {
             type: 'feature',
@@ -97,6 +103,11 @@ define([
             },
             identifyLayerInfos: {
                 layerIds: [2, 4, 5, 8, 12, 21]
+            },
+            legendLayerInfos: {
+                layerInfo: {
+                    hideLayers: [21]
+                }
             }
   }, {
             type: 'dynamic',

--- a/viewer/js/config/viewer.js
+++ b/viewer/js/config/viewer.js
@@ -109,6 +109,9 @@ define([
                 imageParameters: imageParameters,
                 showInLegend: false
             },
+            legendLayerInfos: {
+                exclude: true
+            },
             layerControlLayerInfos: {
                 swipe: true,
                 metadataUrl: true,

--- a/viewer/js/viewer/Controller.js
+++ b/viewer/js/viewer/Controller.js
@@ -270,12 +270,15 @@ define([
                 excludeLayerFromLegend = layer.legendLayerInfos.exclude;
             }
 			if ( !excludeLayerFromLegend ) {
-				this.legendLayerInfos.unshift (
-					{ //unshift instead of push to keep layer ordering in legend intact
-						layer: l,
-						title: layer.title || null
-					}
-				);
+                var configuredLayerInfo = {};
+                if ( typeof layer.legendLayerInfos !== 'undefined' && typeof layer.legendLayerInfos.layerInfo !== 'undefined' ) {
+                    configuredLayerInfo = layer.legendLayerInfos.layerInfo;
+                }
+                var layerInfo = lang.mixin( {
+                    layer: l,
+                    title: layer.title || null
+                }, configuredLayerInfo );
+				this.legendLayerInfos.unshift ( layerInfo ); //unshift instead of push to keep layer ordering in legend intact
 			}
 			//LayerControl LayerInfos array
 			this.layerControlLayerInfos.unshift({ //unshift instead of push to keep layer ordering in LayerControl intact

--- a/viewer/js/viewer/Controller.js
+++ b/viewer/js/viewer/Controller.js
@@ -265,11 +265,11 @@ define([
 			var l = new Layer(layer.url, layer.options);
 			this.layers.unshift(l); //unshift instead of push to keep layer ordering on map intact
 			//Legend LayerInfos array
-			var showInLegend = true;
-			if ( typeof layer.options.showInLegend !== 'undefined' ) {
-				showInLegend = layer.options.showInLegend;
-			}
-			if ( showInLegend ) {
+			var excludeLayerFromLegend = false;
+            if ( typeof layer.legendLayerInfos !== 'undefined' && typeof layer.legendLayerInfos.exclude !== 'undefined' ) {
+                excludeLayerFromLegend = layer.legendLayerInfos.exclude;
+            }
+			if ( !excludeLayerFromLegend ) {
 				this.legendLayerInfos.unshift (
 					{ //unshift instead of push to keep layer ordering in legend intact
 						layer: l,

--- a/viewer/js/viewer/Controller.js
+++ b/viewer/js/viewer/Controller.js
@@ -265,10 +265,18 @@ define([
 			var l = new Layer(layer.url, layer.options);
 			this.layers.unshift(l); //unshift instead of push to keep layer ordering on map intact
 			//Legend LayerInfos array
-			this.legendLayerInfos.unshift({ //unshift instead of push to keep layer ordering in legend intact
-				layer: l,
-				title: layer.title || null
-			});
+			var showInLegend = true;
+			if ( typeof layer.options.showInLegend !== 'undefined' ) {
+				showInLegend = layer.options.showInLegend;
+			}
+			if ( showInLegend ) {
+				this.legendLayerInfos.unshift (
+					{ //unshift instead of push to keep layer ordering in legend intact
+						layer: l,
+						title: layer.title || null
+					}
+				);
+			}
 			//LayerControl LayerInfos array
 			this.layerControlLayerInfos.unshift({ //unshift instead of push to keep layer ordering in LayerControl intact
 				layer: l,


### PR DESCRIPTION
Add support for hiding operational layers in the legend (legendLayerInfo...s array).  Adds an optional property to the layer options parameter in the operational layers config section of viewer.js which when false will prevent the layer from being added to the legendLayerInfos array.