### PR TITLE
Add support for additional layer types

### DIFF
--- a/viewer/js/gis/dijit/LayerControl.js
+++ b/viewer/js/gis/dijit/LayerControl.js
@@ -66,7 +66,11 @@ define([
             csv: './LayerControl/controls/CSV',
             georss: './LayerControl/controls/GeoRSS',
             wms: './LayerControl/controls/WMS',
-            kml: './LayerControl/controls/KML'
+            kml: './LayerControl/controls/KML',
+            webtiled: './LayerControl/controls/WebTiled',
+            imagevector: './LayerControl/controls/ImageVector',
+            raster: './LayerControl/controls/Raster',
+            stream: './LayerControl/controls/Stream'
         },
         constructor: function (options) {
             options = options || {};

--- a/viewer/js/gis/dijit/LayerControl/controls/ImageVector.js
+++ b/viewer/js/gis/dijit/LayerControl/controls/ImageVector.js
@@ -1,0 +1,29 @@
+define([
+    'dojo/_base/declare',
+    'dijit/_WidgetBase',
+    'dijit/_TemplatedMixin',
+    'dijit/_Contained',
+    './_Control', // layer control base class
+    './../plugins/legendUtil'
+], function (
+    declare,
+    _WidgetBase,
+    _TemplatedMixin,
+    _Contained,
+    _Control,
+    legendUtil
+) {
+    var ImageVectorControl = declare([_WidgetBase, _TemplatedMixin, _Contained, _Control], {
+        _layerType: 'overlay', // constant
+        _esriLayerType: 'imagevector', // constant
+        _layerTypeInit: function () {
+            if (legendUtil.isLegend(this.controlOptions.noLegend, this.controller.noLegend)) {
+                this._expandClick();
+                legendUtil.layerLegend(this.layer, this.expandNode);
+            } else {
+                this._expandRemove();
+            }
+        }
+    });
+    return ImageVectorControl;
+});

--- a/viewer/js/gis/dijit/LayerControl/controls/Raster.js
+++ b/viewer/js/gis/dijit/LayerControl/controls/Raster.js
@@ -1,0 +1,23 @@
+define([
+    'dojo/_base/declare',
+    'dijit/_WidgetBase',
+    'dijit/_TemplatedMixin',
+    'dijit/_Contained',
+    './_Control' // layer control base class
+], function (
+    declare,
+    _WidgetBase,
+    _TemplatedMixin,
+    _Contained,
+    _Control
+) {
+    var RasterControl = declare([_WidgetBase, _TemplatedMixin, _Contained, _Control], {
+        _layerType: 'overlay', // constant
+        _esriLayerType: 'raster', // constant
+        // create and legend
+        _layerTypeInit: function () {
+            this._expandRemove();
+        }
+    });
+    return RasterControl;
+});

--- a/viewer/js/gis/dijit/LayerControl/controls/Stream.js
+++ b/viewer/js/gis/dijit/LayerControl/controls/Stream.js
@@ -1,0 +1,30 @@
+define([
+    'dojo/_base/declare',
+    'dijit/_WidgetBase',
+    'dijit/_TemplatedMixin',
+    'dijit/_Contained',
+    './_Control', // layer control base class
+    './../plugins/legendUtil'
+], function (
+    declare,
+    _WidgetBase,
+    _TemplatedMixin,
+    _Contained,
+    _Control,
+    legendUtil
+) {
+    var StreamControl = declare([_WidgetBase, _TemplatedMixin, _Contained, _Control], {
+        _layerType: 'overlay', // constant
+        _esriLayerType: 'raster', // constant
+        // create and legend
+        _layerTypeInit: function () {
+            if (legendUtil.isLegend(this.controlOptions.noLegend, this.controller.noLegend)) {
+                this._expandClick();
+                legendUtil.layerLegend(this.layer, this.expandNode);
+            } else {
+                this._expandRemove();
+            }
+        }
+    });
+    return StreamControl;
+});

--- a/viewer/js/gis/dijit/LayerControl/controls/WebTiled.js
+++ b/viewer/js/gis/dijit/LayerControl/controls/WebTiled.js
@@ -1,0 +1,22 @@
+define([
+    'dojo/_base/declare',
+    'dijit/_WidgetBase',
+    'dijit/_TemplatedMixin',
+    'dijit/_Contained',
+    './_Control' // layer control base class
+], function (
+    declare,
+    _WidgetBase,
+    _TemplatedMixin,
+    _Contained,
+    _Control
+) {
+    var WebTiledControl = declare([_WidgetBase, _TemplatedMixin, _Contained, _Control], {
+        _layerType: 'overlay', // constant
+        _esriLayerType: 'webtiled', // constant
+        _layerTypeInit: function () {
+            this._expandRemove();
+        }
+    });
+    return WebTiledControl;
+});

--- a/viewer/js/viewer/Controller.js
+++ b/viewer/js/viewer/Controller.js
@@ -226,15 +226,20 @@ define([
 			this.layers = [];
 			var layerTypes = {
 				csv: 'CSV',
+				dataadapter: 'DataAdapterFeature', //untested
 				dynamic: 'ArcGISDynamicMapService',
 				feature: 'Feature',
 				georss: 'GeoRSS',
 				image: 'ArcGISImageService',
+				imagevector: 'ArcGISImageServiceVector',
 				kml: 'KML',
 				label: 'Label', //untested
 				mapimage: 'MapImage', //untested
 				osm: 'OpenStreetMap',
+				raster: 'Raster',
+				stream: 'Stream',
 				tiled: 'ArcGISTiledMapService',
+				webtiled: 'WebTiled',
 				wms: 'WMS',
 				wmts: 'WMTS' //untested
 			};


### PR DESCRIPTION
Add support for the following layer types to CMV Controller and the layerControl widget:

* WebTiledLayer
* ArcGISImageServiceVectorLayer (with legend)
* RasterLayer
* StreamLayer (with Legend)

Add support for the following layer types to Controller:

* DataAdaptorFeatureLayer (untested)