### PR TITLE
Allow the use of the popup's setContent method.

### DIFF
--- a/viewer/js/gis/dijit/Identify.js
+++ b/viewer/js/gis/dijit/Identify.js
@@ -308,7 +308,8 @@ define([
         },
 
         getInfoTemplate: function (layer, layerId, result) {
-            var popup = null;
+            var popup = null, 
+                content = null;
             if (result) {
                 layerId = result.layerId;
             } else if (layerId === null) {
@@ -321,7 +322,13 @@ define([
                     popup = this.identifies[layer.id][layerId];
                     if (popup) {
                         if (typeof (popup.declaredClass) !== 'string') { // has it been created already?
+                            if (popup.content) {
+                                content = popup.content;
+                            }
                             popup = new PopupTemplate(popup);
+                            if (content) {
+                                popup.setContent(content);
+                            }
                             this.identifies[layer.id][layerId] = popup;
                         }
                     }


### PR DESCRIPTION
This is an edit of the pull request [here](https://github.com/cmv/cmv-app/pull/416). Check for a content value in the popup identify config and if it exists, call the setContent method on the popup after initializing it.

The `InfoTemplate` class has a setContent method which is inherited by the `PopupInfo` class. This method allows the user to set a custom function which can return widgets and custom html formatting. See [Format info window](https://developers.arcgis.com/javascript/jshelp/intro_formatinfowindow.html)