### PR TITLE
limit geocoder search to map extent

### DIFF
--- a/viewer/js/gis/dijit/Geocoder.js
+++ b/viewer/js/gis/dijit/Geocoder.js
@@ -73,6 +73,12 @@ define([
             if (this.mapRightClickMenu) {
                 this.addRightClickMenu();
             }
+            if (this.mapExtentSearch) {
+                this.geocoder.arcgisGeocoder.searchExtent = this.map.extent.getExtent();
+                this.map.on('extent-change', lang.hitch(this, function (evt) {
+                    this.geocoder.arcgisGeocoder.searchExtent = evt.extent;
+                }));
+            }
         },
         addRightClickMenu: function () {
             this.map.on('MouseDown', lang.hitch(this, function (evt) {


### PR DESCRIPTION
CMV Geocoder option `mapExtentSearch: true` sets `arcgisGeocoder.searchExtent` to map extent when widget loads and on 'extent-change'.