### PR TITLE
GIS Stackexchange dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ There are many ways to contribute to CMV:
 
 2. __Create documentation__ Please contribute to the [cmv documentation repo](https://github.com/cmv/cmv-docs).
 
-3. __Answer Questions at Stack Exchange__ - [gis.stackexchange.com](https://gis.stackexchange.com/tag/cmv) is the prime destination for our Frequently Asked Questions (FAQs). Please answer questions and help new developers get more comfortable with CMV.
+3. __Answer Questions at Stack Exchange__ - [gis.stackexchange.com](https://gis.stackexchange.com/questions/tagged/configurable-map-viewer) is the prime destination for our Frequently Asked Questions (FAQs). Please answer questions and help new developers get more comfortable with CMV.
 
 4. __Join the Chat Room__ - Lots of us in CMV community hang out in the chat room on [Gitter](https://gitter.im/cmv/cmv-app/). Feel free to hangout with us, answer questions and throw out ideas.
 


### PR DESCRIPTION
The GIS Stackexchange has changed the CMV tag. Updating readme link