### PR TITLE
Add ability to nest the viewer in a specific DOM element by ID

### DIFF
--- a/viewer/js/config/viewer.js
+++ b/viewer/js/config/viewer.js
@@ -53,6 +53,10 @@ define([
             zoom: 5,
             sliderStyle: 'small'
         },
+        // if needed, uncomment the container section and specify an existing DOM node ID to place the viewer inside that element
+        //container: {
+        //    id: 'cmv'
+        //},
         // panes: {
         // 	left: {
         // 		splitter: true

--- a/viewer/js/viewer/Controller.js
+++ b/viewer/js/viewer/Controller.js
@@ -123,11 +123,12 @@ define([
 				}
 			}
 
+			var container = (this.config.container && this.config.container.id && dom.byId(this.config.container.id)) || document.body;
 			this.panes.outer = new BorderContainer({
 				id: 'borderContainerOuter',
 				design: 'sidebar',
 				gutters: false
-			}).placeAt(document.body);
+			}).placeAt(container);
 
 			var options, placeAt, type;
 			for (key in panes) {


### PR DESCRIPTION
This pull request adds support in the viewer's controller for specifying the DOM element that the viewer's main BorderContainer should be added to via an optional viewer.js config file setting.

This helps with custom layouts where it's undesirable to append the BorderContainer to the document body.  The current behavior is maintained if new 'container.id' setting is not set.