### PR TITLE
Added new `layerIds` option to layerControl configuration.

### DIFF
--- a/viewer/js/config/viewer.js
+++ b/viewer/js/config/viewer.js
@@ -124,10 +124,16 @@ define([
                 id: 'louisvillePubSafety',
                 opacity: 1.0,
                 visible: true,
-                imageParameters: buildImageParameters()
+                imageParameters: buildImageParameters({
+                    layerIds: [0, 2, 4, 5, 8, 10, 12, 21],
+                    layerOption: 'show'
+                })
             },
             identifyLayerInfos: {
                 layerIds: [2, 4, 5, 8, 12, 21]
+            },
+            layerControlLayerInfos: {
+                layerIds: [0, 2, 4, 5, 8, 9, 10, 12, 21]
             },
             legendLayerInfos: {
                 layerInfo: {

--- a/viewer/js/gis/dijit/LayerControl/controls/_DynamicFolder.js
+++ b/viewer/js/gis/dijit/LayerControl/controls/_DynamicFolder.js
@@ -35,6 +35,10 @@ define([
         _expandClickHandler: null,
         postCreate: function () {
             this.inherited(arguments);
+            // Should the control be visible or hidden?
+            if (this.control.controlOptions.layerIds && this.control.controlOptions.layerIds.indexOf(this.sublayerInfo.id) < 0) {
+                domClass.add(this.domNode, 'layerControlHidden');
+            }
             var checkNode = this.checkNode;
             domAttr.set(checkNode, 'data-sublayer-id', this.sublayerInfo.id);
             domClass.add(checkNode, this.control.layer.id + '-layerControlSublayerCheck');

--- a/viewer/js/gis/dijit/LayerControl/controls/_DynamicSublayer.js
+++ b/viewer/js/gis/dijit/LayerControl/controls/_DynamicSublayer.js
@@ -45,6 +45,10 @@ define([
         _expandClickHandler: null,
         postCreate: function () {
             this.inherited(arguments);
+            // Should the control be visible or hidden?
+            if (this.control.controlOptions.layerIds && this.control.controlOptions.layerIds.indexOf(this.sublayerInfo.id) < 0) {
+                domClass.add(this.domNode, 'layerControlHidden');
+            }
             var checkNode = this.checkNode;
             domAttr.set(checkNode, 'data-sublayer-id', this.sublayerInfo.id);
             domClass.add(checkNode, this.control.layer.id + '-layerControlSublayerCheck');

--- a/viewer/js/gis/dijit/LayerControl/css/LayerControl.css
+++ b/viewer/js/gis/dijit/LayerControl/css/LayerControl.css
@@ -67,6 +67,13 @@
     text-align: center;
 }
 
+.layerControlDijit .layerControlHidden {
+    display: none;
+}
+.layerControlDijit .layerControlVisible {
+    display: block;
+}
+
 .layerControlDijit .layerControlIndent {
     padding-left: 22px;
 }


### PR DESCRIPTION
This array determines which sublayer and folder controls are visible.
The visibility of the actual sublayers is not affected.

Also includes `layerIds` array in imageParameters to demonstrate how to
set the initial visibility of sublayers.