### PR TITLE
Add new `_createMap` method to allow custom mixins to override

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -151,7 +151,6 @@
         "comma-style": 2,
         "computed-property-spacing": [2, "never"],
         "consistent-this": [2, "self"],
-        "constructor-super": 2,
         "func-style": [2, "declaration"],
         "indent": [2, 4],
         "key-spacing": [2, {

--- a/.eslintrc
+++ b/.eslintrc
@@ -153,7 +153,6 @@
         "consistent-this": [2, "self"],
         "constructor-super": 2,
         "func-style": [2, "declaration"],
-        "id-match": [2, "^[a-z]+([A-Z][a-z]+)*$", {"properties": true}],
         "indent": [2, 4],
         "key-spacing": [2, {
             "beforeColon": false,

--- a/viewer/js/viewer/_MapMixin.js
+++ b/viewer/js/viewer/_MapMixin.js
@@ -27,8 +27,7 @@ define([
             var returnDeferred = new Deferred();
             var returnWarnings = [];
 
-            var container = dom.byId(this.config.layout.map) || 'mapCenter';
-            this.map = new Map(container, this.config.mapOptions);
+            this._createMap();
 
             if (this.config.mapOptions.basemap) {
                 this.map.on('load', lang.hitch(this, '_initLayers', returnWarnings));
@@ -42,6 +41,11 @@ define([
                 returnDeferred.resolve(returnWarnings);
             }
             return returnDeferred;
+        },
+
+        _createMap: function () {
+            var container = dom.byId(this.config.layout.map) || 'mapCenter';
+            this.map = new Map(container, this.config.mapOptions);
         },
 
         _onLayersAddResult: function (returnDeferred, returnWarnings, lyrsResult) {


### PR DESCRIPTION
the method.

This is useful when using CMV with BootstrapMap
(https://github.com/Esri/bootstrap-map-js).