### PR TITLE
Feature/add support for wfs layer

### DIFF
--- a/viewer/js/gis/dijit/LayerControl.js
+++ b/viewer/js/gis/dijit/LayerControl.js
@@ -69,6 +69,7 @@ define([
             csv: './LayerControl/controls/CSV',
             georss: './LayerControl/controls/GeoRSS',
             wms: './LayerControl/controls/WMS',
+            wfs: './LayerControl/controls/WFS',
             kml: './LayerControl/controls/KML',
             vectortile: './LayerControl/controls/VectorTile',
             webtiled: './LayerControl/controls/WebTiled',

--- a/viewer/js/gis/dijit/LayerControl/controls/WFS.js
+++ b/viewer/js/gis/dijit/LayerControl/controls/WFS.js
@@ -10,8 +10,7 @@ define([
     _WidgetBase,
     _TemplatedMixin,
     _Contained,
-    _Control,
-    legendUtil
+    _Control
 ) {
     'use strict';
 

--- a/viewer/js/gis/dijit/LayerControl/controls/WFS.js
+++ b/viewer/js/gis/dijit/LayerControl/controls/WFS.js
@@ -1,0 +1,26 @@
+define([
+    'dojo/_base/declare',
+    'dijit/_WidgetBase',
+    'dijit/_TemplatedMixin',
+    'dijit/_Contained',
+    './_Control', // layer control base class
+    './../plugins/legendUtil'
+], function (
+    declare,
+    _WidgetBase,
+    _TemplatedMixin,
+    _Contained,
+    _Control,
+    legendUtil
+) {
+    'use strict';
+
+    var WFSControl = declare([_WidgetBase, _TemplatedMixin, _Contained, _Control], {
+        _layerType: 'vector', // constant
+        _esriLayerType: 'wfs', // constant
+        _layerTypeInit: function () {
+            this._expandRemove();
+        }
+    });
+    return WFSControl;
+});

--- a/viewer/js/viewer/_MapMixin.js
+++ b/viewer/js/viewer/_MapMixin.js
@@ -76,6 +76,7 @@ define([
                 tiled: 'ArcGISTiledMapService',
                 vectortile: 'VectorTile',
                 webtiled: 'WebTiled',
+                wfs: 'WFS',
                 wms: 'WMS',
                 wmts: 'WMTS' //untested
             };


### PR DESCRIPTION
Adding support for the WFS layer added to the ESRI API at v3.14. …
This layer type is still considered beta in version 3.15.

To avoid conflicts, I will merge the develop branch into this one after PR #500 and PR #503 have been merged.