### PR TITLE
Added 'draggable' property to identify config object

### DIFF
--- a/viewer/js/config/identify.js
+++ b/viewer/js/config/identify.js
@@ -4,6 +4,7 @@ define({
 	mapRightClickMenu: true,
 	identifyLayerInfos: true,
 	identifyTolerance: 5,
+	draggable: false,
 
 	// config object definition:
 	//	{<layer id>:{


### PR DESCRIPTION
After looking through CMV docs, it seemed most appropriate to just put
this property here.  The sample config object in the docs is for
viewer.js or custom info windows and this is a pretty straightforward
setting.