### PR TITLE
Sub layer support

### DIFF
--- a/viewer/js/config/viewer.js
+++ b/viewer/js/config/viewer.js
@@ -133,7 +133,10 @@ define([
                 layerIds: [2, 4, 5, 8, 12, 21]
             },
             layerControlLayerInfos: {
-                layerIds: [0, 2, 4, 5, 8, 9, 10, 12, 21]
+                //layerIds: [0, 2, 4, 5, 8, 9, 10, 12, 21]
+				includeUnspecifiedLayers : true,
+				//excludedLayers : [1,3],
+				subLayerInfos: [{id:0,name:"Layer 1",defaultVisibility:false},{id:2,name:"Layer 2"},{id:4,name:"Layer 3"},{id:5,name:"Layer 4"},{id:8,name:"Layer 5"},{id:9},{id:10},{id:12,name:"Layer 6"},{id:21,name:"Layer 7"}]
             },
             legendLayerInfos: {
                 layerInfo: {

--- a/viewer/js/config/viewer.js
+++ b/viewer/js/config/viewer.js
@@ -133,10 +133,7 @@ define([
                 layerIds: [2, 4, 5, 8, 12, 21]
             },
             layerControlLayerInfos: {
-                //layerIds: [0, 2, 4, 5, 8, 9, 10, 12, 21]
-				includeUnspecifiedLayers : true,
-				//excludedLayers : [1,3],
-				subLayerInfos: [{id:0,name:"Layer 1",defaultVisibility:false},{id:2,name:"Layer 2"},{id:4,name:"Layer 3"},{id:5,name:"Layer 4"},{id:8,name:"Layer 5"},{id:9},{id:10},{id:12,name:"Layer 6"},{id:21,name:"Layer 7"}]
+                layerIds: [0, 2, 4, 5, 8, 9, 10, 12, 21]
             },
             legendLayerInfos: {
                 layerInfo: {

--- a/viewer/js/gis/dijit/LayerControl/controls/Dynamic.js
+++ b/viewer/js/gis/dijit/LayerControl/controls/Dynamic.js
@@ -100,29 +100,40 @@ define([
         _createSublayers: function (layer) {
             // check for single sublayer - if so no sublayer/folder controls
             if (layer.layerInfos.length > 1) {
+                var allLayers = array.map(layer.layerInfos, function (l) { 
+                    return l.id; 
+                });
                 array.forEach(layer.layerInfos, lang.hitch(this, function (info) {
+                    // see if there was any override needed from the subLayerInfos array in the controlOptions
+                    var sublayerInfo = array.filter(this.controlOptions.subLayerInfos, function (sli) {
+                        return sli.id === info.id;
+                    }).shift();
+                    lang.mixin(info, sublayerInfo);
                     var pid = info.parentLayerId,
                         slids = info.subLayerIds,
                         controlId = layer.id + '-' + info.id + '-sublayer-control',
                         control;
-                    if (pid === -1 && slids === null) {
-                        // it's a top level sublayer
-                        control = new DynamicSublayer({
-                            id: controlId,
-                            control: this,
-                            sublayerInfo: info,
-                            icons: this.icons
-                        });
-                        domConst.place(control.domNode, this.expandNode, 'last');
-                    } else if (pid === -1 && slids !== null) {
-                        // it's a top level folder
-                        control = new DynamicFolder({
-                            id: controlId,
-                            control: this,
-                            sublayerInfo: info,
-                            icons: this.icons
-                        });
-                        domConst.place(control.domNode, this.expandNode, 'last');
+                    // it's a top level 
+                    if (pid === -1 || allLayers.indexOf(pid) === -1) {
+                        if (slids === null) {
+                            // it's a top level sublayer
+                            control = new DynamicSublayer({
+                                id: controlId,
+                                control: this,
+                                sublayerInfo: info,
+                                icons: this.icons
+                            });
+                            domConst.place(control.domNode, this.expandNode, 'last');
+                        } else if (slids !== null) {
+                            // it's a top level folder
+                            control = new DynamicFolder({
+                                id: controlId,
+                                control: this,
+                                sublayerInfo: info,
+                                icons: this.icons
+                            });
+                            domConst.place(control.domNode, this.expandNode, 'last');
+                        }
                     } else if (pid !== -1 && slids !== null) {
                         // it's a nested folder
                         control = new DynamicFolder({

--- a/viewer/js/gis/dijit/LayerControl/controls/_DynamicFolder.js
+++ b/viewer/js/gis/dijit/LayerControl/controls/_DynamicFolder.js
@@ -36,6 +36,15 @@ define([
         _handlers: [],
         postCreate: function () {
             this.inherited(arguments);
+            // Should the control be visible or hidden (depends on subLayerInfos)?
+            if (this.control.controlOptions.subLayerInfos && !this.control.controlOptions.includeUnspecifiedLayers) {
+                var subLayerInfos = array.map(this.control.controlOptions.subLayerInfos, function (sli) {
+                    return sli.id;
+                });
+                if (array.indexOf(subLayerInfos, this.sublayerInfo.id) < 0) {
+                    domClass.add(this.domNode, 'layerControlHidden');
+                }
+            }
             // Should the control be visible or hidden?
             if (this.control.controlOptions.layerIds && array.indexOf(this.control.controlOptions.layerIds, this.sublayerInfo.id) < 0) {
                 domClass.add(this.domNode, 'layerControlHidden');

--- a/viewer/js/gis/dijit/LayerControl/controls/_DynamicSublayer.js
+++ b/viewer/js/gis/dijit/LayerControl/controls/_DynamicSublayer.js
@@ -46,6 +46,15 @@ define([
         _handlers: [],
         postCreate: function () {
             this.inherited(arguments);
+            // Should the control be visible or hidden (depends on subLayerInfos)?
+            if (this.control.controlOptions.subLayerInfos && !this.control.controlOptions.includeUnspecifiedLayers) {
+                var subLayerInfos = array.map(this.control.controlOptions.subLayerInfos, function (sli) {
+                    return sli.id;
+                });
+                if (array.indexOf(subLayerInfos, this.sublayerInfo.id) < 0) {
+                    domClass.add(this.domNode, 'layerControlHidden');
+                }
+            }
             // Should the control be visible or hidden?
             if (this.control.controlOptions.layerIds && array.indexOf(this.control.controlOptions.layerIds, this.sublayerInfo.id) < 0) {
                 domClass.add(this.domNode, 'layerControlHidden');
@@ -56,7 +65,6 @@ define([
             if (array.indexOf(this.control.layer.visibleLayers, this.sublayerInfo.id) !== -1) {
                 this._setSublayerCheckbox(true, checkNode);
             } else {
-
                 this._setSublayerCheckbox(false, checkNode);
             }
             this._handlers.push(on(checkNode, 'click', lang.hitch(this, function () {

--- a/viewer/js/viewer/_MapMixin.js
+++ b/viewer/js/viewer/_MapMixin.js
@@ -159,64 +159,6 @@ define([
                 if (idOptions.exclude !== true) {
                     this.identifyLayerInfos.push(idOptions);
                 }
-                if (layer.layerControlLayerInfos) {
-                    l.on('load', lang.hitch(this, '_applyLayerControlOptions', layer.layerControlLayerInfos));
-                }
-            }
-        },
-        _applyLayerControlOptions: function (controlOptions, args) {
-            if (typeof controlOptions.includeUnspecifiedLayers === 'undefined' && typeof controlOptions.subLayerInfos === 'undefined' && typeof controlOptions.excludedLayers === 'undefined') {
-                return;
-            }			
-            var esriLayerInfos = [],
-                layer = args.layer;
-            // Case 1: only show the layers that are explicitly listed
-            if (!controlOptions.includeUnspecifiedLayers && controlOptions.subLayerInfos && controlOptions.subLayerInfos.length !== 0) {            
-                var subLayerInfos = array.map(controlOptions.subLayerInfos, function (sli) {
-                    return sli.id;
-                });
-                array.forEach(layer.layerInfos, function (li) {
-                    if (array.indexOf(subLayerInfos, li.id) !== -1) {
-                        esriLayerInfos.push(li);
-                    }
-                });
-            // Case 2: show ALL layers except those in the excluded list
-            } else if (controlOptions.excludedLayers) {
-                array.forEach(layer.layerInfos, function (li) {
-                    if (array.indexOf(controlOptions.excludedLayers, li.id) === -1) {
-                        esriLayerInfos.push(li);
-                    }
-                });
-			// Case 3: just override the values found in the subLayerInfos
-            } else if (controlOptions.subLayerInfos) {
-                // show ALL layers that are in the map service's layerInfos, but take care to override the properties of each subLayerInfo as configured
-                this._mixinLayerInfos(layer.layerInfos, controlOptions.subLayerInfos);
-                return;
-            }
-            // Finally, if we made use of the esriLayerInfos, make sure to apply all the subLayerInfos that were defined to our new array of esri layer infos
-            if (controlOptions.subLayerInfos) {
-                this._mixinLayerInfos(esriLayerInfos, controlOptions.subLayerInfos);
-            }
-            layer.layerInfos = esriLayerInfos;        
-        },
-        _mixinLayerInfos: function (esriLayerInfos, subLayerInfos) {
-            // for each of the sublayers, go through the subLayerInfos from the controlOptions and see if defaultVisiblity is set to true or false
-            // then set each of the layer.layerInfos defaultVisibility appropriately
-			// assume defaultVisibility is true if it's not defined
-            if (subLayerInfos && subLayerInfos.length !== 0) {
-                array.forEach(subLayerInfos, function (sli) {
-                    if (typeof sli.defaultVisibility === 'undefined') {
-                        sli.defaultVisibility = true;
-                    }
-                });
-                array.forEach(esriLayerInfos, function (li) {
-                    var sli = array.filter(subLayerInfos, function (s) {
-                        return s.id === li.id;
-                    }).shift();
-                    if (sli) {
-                        lang.mixin(li, sli);
-                    }
-                });
             }
         },
         initMapComplete: function (warnings) {

--- a/viewer/js/viewer/_MapMixin.js
+++ b/viewer/js/viewer/_MapMixin.js
@@ -159,9 +159,66 @@ define([
                 if (idOptions.exclude !== true) {
                     this.identifyLayerInfos.push(idOptions);
                 }
+                if (layer.layerControlLayerInfos) {
+                    l.on('load', lang.hitch(this, '_applyLayerControlOptions', layer.layerControlLayerInfos));
+                }
             }
         },
-
+        _applyLayerControlOptions: function (controlOptions, args) {
+            if (typeof controlOptions.includeUnspecifiedLayers === 'undefined' && typeof controlOptions.subLayerInfos === 'undefined' && typeof controlOptions.excludedLayers === 'undefined') {
+                return;
+            }			
+            var esriLayerInfos = [],
+                layer = args.layer;
+            // Case 1: only show the layers that are explicitly listed
+            if (!controlOptions.includeUnspecifiedLayers && controlOptions.subLayerInfos && controlOptions.subLayerInfos.length !== 0) {            
+                var subLayerInfos = array.map(controlOptions.subLayerInfos, function (sli) {
+                    return sli.id;
+                });
+                array.forEach(layer.layerInfos, function (li) {
+                    if (array.indexOf(subLayerInfos, li.id) !== -1) {
+                        esriLayerInfos.push(li);
+                    }
+                });
+            // Case 2: show ALL layers except those in the excluded list
+            } else if (controlOptions.excludedLayers) {
+                array.forEach(layer.layerInfos, function (li) {
+                    if (array.indexOf(controlOptions.excludedLayers, li.id) === -1) {
+                        esriLayerInfos.push(li);
+                    }
+                });
+			// Case 3: just override the values found in the subLayerInfos
+            } else if (controlOptions.subLayerInfos) {
+                // show ALL layers that are in the map service's layerInfos, but take care to override the properties of each subLayerInfo as configured
+                this._mixinLayerInfos(layer.layerInfos, controlOptions.subLayerInfos);
+                return;
+            }
+            // Finally, if we made use of the esriLayerInfos, make sure to apply all the subLayerInfos that were defined to our new array of esri layer infos
+            if (controlOptions.subLayerInfos) {
+                this._mixinLayerInfos(esriLayerInfos, controlOptions.subLayerInfos);
+            }
+            layer.layerInfos = esriLayerInfos;        
+        },
+        _mixinLayerInfos: function (esriLayerInfos, subLayerInfos) {
+            // for each of the sublayers, go through the subLayerInfos from the controlOptions and see if defaultVisiblity is set to true or false
+            // then set each of the layer.layerInfos defaultVisibility appropriately
+			// assume defaultVisibility is true if it's not defined
+            if (subLayerInfos && subLayerInfos.length !== 0) {
+                array.forEach(subLayerInfos, function (sli) {
+                    if (typeof sli.defaultVisibility === 'undefined') {
+                        sli.defaultVisibility = true;
+                    }
+                });
+                array.forEach(esriLayerInfos, function (li) {
+                    var sli = array.filter(subLayerInfos, function (s) {
+                        return s.id === li.id;
+                    }).shift();
+                    if (sli) {
+                        lang.mixin(li, sli);
+                    }
+                });
+            }
+        },
         initMapComplete: function (warnings) {
             if (warnings && warnings.length > 0) {
                 this.handleError({


### PR DESCRIPTION
These changes allow the user to have granular control over each subLayer
in a dynamic Map service.  Now, instead of having to just use the name
of the layer in the map, you can override it to whatever you'd like.
you can also redefine the min/max scale of the subLayer.
see the layerInfo properties defined here:
https://developers.arcgis.com/javascript/jsapi/layerinfo-amd.html

In addition to the subLayerInfo support, i've added two other properties
to the layerControlLayerInfos object.
1) subLayerInfos : array of layerInfos that should override the dynamic
map service's default layerInfos
2) excludedLayers : an array of layer ids that should not be exposed in
the map service
3) includeUnspecifiedLayers: boolean --> if true, then all layers in the
dynamic map service will be added, not just the ones listed in
subLayerInfos.  the excludeLayers list will still be honored.

```
layerControlLayerInfos: {
//layerIds: [0, 2, 4, 5, 8, 9, 10, 12, 21]
includeUnspecifiedLayers : true,
excludedLayers : [1,3],
subLayerInfos: [{id:0,name:"Layer
1",defaultVisibility:false} , {id:2,name:"Layer 2"}, {id:4,name:"Layer
3"} ,{id:5,name:"Layer 4"}, {id:8,name:"Layer
5"} ,{id:9},{id:10}, {id:12,name:"Layer 6"},  {id:21,name:"Layer 7"}]
},
```