### PR TITLE
add nls support to the help widget

### DIFF
--- a/viewer/js/gis/dijit/Help.js
+++ b/viewer/js/gis/dijit/Help.js
@@ -9,17 +9,18 @@ define([
     'dojo/_base/lang',
     'dojo/aspect',
     'dojo/text!./Help/templates/HelpDialog.html',
+    'dojo/i18n!./Help/nls/resource',
     'dijit/form/Button',
     'dijit/layout/TabContainer',
     'dijit/layout/ContentPane',
     'xstyle/css!./Help/css/Help.css'
-], function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, _FloatingWidgetMixin, domConstruct, on, lang, aspect, template) {
+], function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, _FloatingWidgetMixin, domConstruct, on, lang, aspect, template, i18n) {
 
     return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, _FloatingWidgetMixin], {
         widgetsInTemplate: true,
         templateString: template,
-        title: 'Help',
-        html: '<a href="#">Help</a>',
+        i18n: i18n,
+        html: '<a href="#">link</a>'.replace('link', i18n.link),
         domTarget: 'helpDijit',
         draggable: false,
         baseClass: 'helpDijit',

--- a/viewer/js/gis/dijit/Help/nls/pt-pt/resource.js
+++ b/viewer/js/gis/dijit/Help/nls/pt-pt/resource.js
@@ -1,0 +1,36 @@
+define({
+    link: 'Ajuda',
+    navigation: {
+        title: 'Navegação',
+        description: 'Navegação no mapa usando o rato e o teclado',
+        pan1: 'Arrastar para mover',
+        recenter: 'SHIFT + Clique para centrar',
+        zoomIn1: 'SHIFT + Arrastar para aproximar à área',
+        zoomOut1: 'SHIFT + CTRL + Arrastar para afastar',
+        zoomIn2: 'Mover roda de deslocação do rato para a frente para aproximar',
+        zoomOut2: 'Mover roda de deslocação do rato para trás para afastar',
+        pan2: 'Teclas de seta para mover',
+        zoomInLevel: 'Tecla + para aproximar um nível',
+        zoomOutLevel: 'Tecla - para afastar um nível',
+        zoomCenter: 'Duplo clique para centrar e aproximar'
+    },
+    search: {
+        title: 'Pesquisa',
+        description: 'A caixa de pesquisa suporta vários tipos de pesquisa:',
+        address: 'Pesquisar por endereço',
+        place: 'Pesquisar por nome do local',
+        etc: 'Pesquisar por código postal, região, etc.'
+    },
+    tools: {
+        title: 'Ferramentas',
+        description: 'Além das funcionalidades de pesquisa, são incluídas as seguintes ferramentas:',
+        measure: {
+            title: 'Medir',
+            description: 'A ferramenta de medição permite desenhar um ponto, linha, ou polígono, no mapa e especificar a unidade de medida.'
+        },
+        print: {
+            title: 'Imprimir',
+            description: 'Este mapa pode ser exportado para diferentes formatos e modelos.'
+        }
+    }
+});

--- a/viewer/js/gis/dijit/Help/nls/resource.js
+++ b/viewer/js/gis/dijit/Help/nls/resource.js
@@ -1,0 +1,39 @@
+define({
+    root: {
+        link: 'Help',
+        navigation: {
+            title: 'Navigation',
+            description: 'Map navigation using mouse and keyboard:',
+            pan1: 'Drag to pan',
+            recenter: 'SHIFT + Click to recenter',
+            zoomIn1: 'SHIFT + Drag to zoom in',
+            zoomOut1: 'SHIFT + CTRL + Drag to zoom out',
+            zoomIn2: 'Mouse Scroll Forward to zoom in',
+            zoomOut2: 'Mouse Scroll Backward to zoom out',
+            pan2: 'Use Arrow keys to pan',
+            zoomInLevel: '+ key to zoom in a level',
+            zoomOutLevel: '- key to zoom out a level',
+            zoomCenter: 'Double Click to Center and Zoom in'
+        },
+        search: {
+            title: 'Search',
+            description: 'A variety of searches can be performed in the search box:',
+            address: 'Search by Address',
+            place: 'Search by Place Name',
+            etc: 'Search By Zip Code, County, etc.'
+        },
+        tools: {
+            title: 'Tools',
+            description: 'In addition to Search capabilities, the following tools are provided:',
+            measure: {
+                title: 'Measure',
+                description: 'The measure tool provides the capabilities to draw a point, line, or polygon on the map and specify the unit of measurement.'
+            },
+            print: {
+                title: 'Print',
+                description: 'This map can be exported to various formats and layouts.'
+            }
+        }
+    },
+    'pt-pt': true
+});

--- a/viewer/js/gis/dijit/Help/templates/HelpDialog.html
+++ b/viewer/js/gis/dijit/Help/templates/HelpDialog.html
@@ -2,42 +2,42 @@
     <div data-dojo-type="dijit/layout/ContentPane" data-dojo-attach-point="containerNode" class="helpContainer">
         <div class="helpNode">
             <div data-dojo-type="dijit/layout/TabContainer" class="helpTabContainer">
-                <div data-dojo-type="dijit/layout/ContentPane" title="Navigation">
+                <div data-dojo-type="dijit/layout/ContentPane" title="${i18n.navigation.title}">
                     <table>
                         <tbody>
                             <tr>
                                 <td>
-                                    Map navigation using mouse and keyboard:
+                                    ${i18n.navigation.description}
                                     <ul class="listdbootstrapFix">
                                         <li>
-                                            Drag to pan
+                                            ${i18n.navigation.pan1}
                                         </li>
                                         <li>
-                                            SHIFT + Click to recenter
+                                            ${i18n.navigation.recenter}
                                         </li>
                                         <li>
-                                            SHIFT + Drag to zoom in
+                                            ${i18n.navigation.zoomIn1}
                                         </li>
                                         <li>
-                                            SHIFT + CTRL + Drag to zoom out
+                                            ${i18n.navigation.zoomOut1}
                                         </li>
                                         <li>
-                                            Mouse Scroll Forward to zoom in
+                                            ${i18n.navigation.zoomIn2}
                                         </li>
                                         <li>
-                                            Mouse Scroll Backward to zoom out
+                                            ${i18n.navigation.zoomOut2}
                                         </li>
                                         <li>
-                                            Use Arrow keys to pan
+                                            ${i18n.navigation.pan2}
                                         </li>
                                         <li>
-                                            + key to zoom in a level
+                                            ${i18n.navigation.zoomInLevel}
                                         </li>
                                         <li>
-                                            - key to zoom out a level
+                                            ${i18n.navigation.zoomOutLevel}
                                         </li>
                                         <li>
-                                            Double Click to Center and Zoom in
+                                            ${i18n.navigation.zoomCenter}
                                         </li>
                                     </ul>
                                 </td>
@@ -45,35 +45,34 @@
                         </tbody>
                     </table>
                 </div>
-                <div data-dojo-type="dijit/layout/ContentPane" title="Search">
-                    A variety of searches can be performed in the search box:
+                <div data-dojo-type="dijit/layout/ContentPane" title="${i18n.search.title}">
+                    ${i18n.search.description}
                     <ul class="listdbootstrapFix">
                         <li>
-                            Search by Address
+                            ${i18n.search.address}
                         </li>
                         <li>
-                            Search by Place Name
+                            ${i18n.search.place}
                         </li>
                         <li>
-                            Search By Zip Code, County, etc.
+                            ${i18n.search.etc}
                         </li>
                     </ul>
                 </div>
-                <div data-dojo-type="dijit/layout/ContentPane" title="Tools">
-                    In addition to Search capabilities, the following tools are provided:
+                <div data-dojo-type="dijit/layout/ContentPane" title="${i18n.tools.title}">
+                    ${i18n.tools.description}
                     <ul class="listdbootstrapFix">
                         <li>
-                            Measure
+                            ${i18n.tools.measure.title}
                         </li>
                         <div>
-                            The measure tool provides the capabilities to draw a point, line, or polygon
-                            on the map and specify the unit of measurement.
+                            ${i18n.tools.measure.description}
                         </div>
                         <li>
-                            Print
+                            ${i18n.tools.print.title}
                         </li>
                         <div>
-                            This map can be exported to varouis formats and layouts
+                            ${i18n.tools.print.description}
                         </div>
                     </ul>
                 </div>


### PR DESCRIPTION
This is an addition to the PR #572. The Help widget was missing.

- Remove widget title from its main source file (it was already defined in config/viewer.js)
- add i18n to the link in the top right corner of the cmv-app main screen
- add i18n to the tabs titles and all content
- includes Portuguese translation (PT-PT)