### PR TITLE
Fix titlePane issue effecting IE 11/M.S. Edge and now Chrome v 55

### DIFF
--- a/viewer/js/gis/dijit/FloatingTitlePane.js
+++ b/viewer/js/gis/dijit/FloatingTitlePane.js
@@ -42,13 +42,17 @@ define([
         },
         startup: function () {
             if (this.titleBarNode && this.canFloat) {
-                if (has('edge') || has('trident')) {
-                    this.dragDelay = 0;
-                }
                 this._moveable = new Moveable(this.domNode, {
                     handle: this.titleBarNode,
                     delay: this.dragDelay
                 });
+                if (this.dragDelay > 0) {
+                    this._moveable.mover.prototype.onMouseUp = function (e) {
+                        this.destroy();
+                        e.preventDefault();
+                        e.stopPropagation();
+                    };
+                }
                 this._titleBarHeight = domStyle.get(this.titleBarNode, 'height');
                 aspect.after(this._moveable, 'onMove', lang.hitch(this, '_dragging'), true);
                 aspect.after(this._moveable, 'onMoveStop', lang.hitch(this, '_endDrag'), true);


### PR DESCRIPTION
With Chrome version 55 (in the Chrome beta and dev channels), a floating titlePane widget does not stop dragging when the mouse is released. This is the same behavior previously experienced in IE 11 and MS Edge. Version 55 is expected to be released to the Chrome stable channel on [December 6th](https://www.chromium.org/developers/calendar).

I believe the issue is related to this [dojo bug](https://bugs.dojotoolkit.org/ticket/17314). Based on that report, this PR overrides the `onMouseUp` in dojo Mover class. The fix has been tested with the effected browser versions as well as Firefox. 