### PR TITLE
basemap widget - support custom and agol basemaps at the same time

### DIFF
--- a/viewer/js/config/basemaps.js
+++ b/viewer/js/config/basemaps.js
@@ -1,8 +1,8 @@
 define([
-    //'esri/dijit/Basemap',
-    //'esri/dijit/BasemapLayer'
+    'esri/dijit/Basemap',
+    'esri/dijit/BasemapLayer',
     'dojo/i18n!./nls/main'
-], function (/* Basemap, BasemapLayer, */i18n) {
+], function (Basemap, BasemapLayer, i18n) {
 
     return {
         map: true, // needs a reference to the map
@@ -64,6 +64,19 @@ define([
                         }
                     ]
                 }
+            },
+            mapboxPirates: {
+                title: 'Pirates (mapbox.com)',
+                basemap: new Basemap({
+                    id: 'mapboxPirates',
+                    layers: [new BasemapLayer({
+                        url: 'https://${subDomain}.tiles.mapbox.com/v3/aj.Sketchy2/${level}/${col}/${row}.png',
+                        copyright: 'mapbox, 2016',
+                        id: 'mapboxPirates',
+                        subDomains: ['a', 'b', 'c', 'd'],
+                        type: 'WebTiledLayer'
+                    })]
+                })
             }
 
             // additional examples of vector tile basemaps (requires v3.16 or higher)
@@ -257,19 +270,6 @@ define([
                     })]
                 })
             },
-            mapboxPirates: {
-                title: 'Pirates (mapbox.com)',
-                basemap: new Basemap({
-                    id: 'mapboxPirates',
-                    layers: [new BasemapLayer({
-                        url: 'https://${subDomain}.tiles.mapbox.com/v3/aj.Sketchy2/${level}/${col}/${row}.png',
-                        copyright: 'mapbox, 2016',
-                        id: 'mapboxPirates',
-                        subDomains: ['a', 'b', 'c', 'd'],
-                        type: 'WebTiledLayer'
-                    })]
-                })
-            }
             */
         }
     };

--- a/viewer/js/config/basemaps.js
+++ b/viewer/js/config/basemaps.js
@@ -6,7 +6,7 @@ define([
 
     return {
         map: true, // needs a reference to the map
-        mode: 'agol', // mut be either 'agol' or 'custom'
+        //mode: 'agol', // mut be either 'agol' or 'custom'
 
         /* optional starting basemap
         / otherwise uses the basemap from the map

--- a/viewer/js/config/basemaps.js
+++ b/viewer/js/config/basemaps.js
@@ -22,45 +22,19 @@ define([
 
         // define all valid basemaps here.
         basemaps: {
-            streets: {
-                title: i18n.basemaps.streets
-            },
-            'streets-night-vector': { // requires v3.16 or higher
-                title: i18n.basemaps.streetsNightVector
-            },
-            'streets-navigation-vector': { // requires v3.16 or higher
-                title: i18n.basemaps.streetsNavigationVector
-            },
-            'streets-relief-vector': { // requires v3.16 or higher
-                title: i18n.basemaps.streetsReliefVector
-            },
-            satellite: {
-                title: i18n.basemaps.satellite
-            },
-            hybrid: {
-                title: i18n.basemaps.hybrid
-            },
-            topo: {
-                title: i18n.basemaps.topo
-            },
-            terrain: {
-                title: i18n.basemaps.terrain
-            },
-            'gray-vector': { // requires v3.16 or higher
-                title: i18n.basemaps.grayVector
-            },
-            'dark-gray-vector': { // requires v3.16 or higher
-                title: i18n.basemaps.darkGrayVector
-            },
-            oceans: {
-                title: i18n.basemaps.oceans
-            },
-            'national-geographic': {
-                title: i18n.basemaps.nationalGeographic
-            },
-            osm: {
-                title: i18n.basemaps.osm
-            },
+            streets: {},
+            'streets-night-vector': {}, // requires v3.16 or higher
+            'streets-navigation-vector': {}, // requires v3.16 or higher
+            'streets-relief-vector': {}, // requires v3.16 or higher
+            satellite: {},
+            hybrid: {},
+            topo: {},
+            terrain: {},
+            'gray-vector': {}, // requires v3.16 or higher
+            'dark-gray-vector': {}, // requires v3.16 or higher
+            oceans: {},
+            'national-geographic': {},
+            osm: {},
             landsatShaded: {
                 title: i18n.basemaps.landsatShaded,
                 basemap: {

--- a/viewer/js/config/nls/es/main.js
+++ b/viewer/js/config/nls/es/main.js
@@ -2,22 +2,8 @@
 define({
     basemaps: {
         davidRumseyMap1812: 'David Rumsey 1812',
-        darkGrayVector: 'Gris oscuro',
         earthAtNight: 'Tierra en la noche',
-        grayVector: 'Gris',
-        hybrid: 'Híbrido',
-        landsatShaded: 'Landsat sombreada',
-        nationalGeographic: 'Nat Geo',
-        oceans: 'Oceános',
-        osm: 'Open Street Map',
-        satellite: 'Satélite',
-        streets: 'Calle',
-        streetsNavigationVector: 'Calle (Navegación)',
-        streetsNightVector: 'Calle (Noche)',
-        streetsReliefVector: 'Calle (Relieve)',
-        terrain: 'Terreno',
-        title: 'Mapas base',
-        topo: 'Topográfico'
+        landsatShaded: 'Landsat sombreada'
     },
     bookmarks: {
         nullIsland: 'Isla nula',

--- a/viewer/js/config/nls/fr/main.js
+++ b/viewer/js/config/nls/fr/main.js
@@ -2,21 +2,8 @@
 define({
     basemaps: {
         davidRumseyMap1812: 'David Rumsey 1812',
-        darkGrayVector: 'Gris foncé',
         earthAtNight: 'Terre la nuit',
-        grayVector: 'Gris',
-        hybrid: 'Hybride',
-        landsatShaded: 'Landsat et relief ombragé',
-        nationalGeographic: 'National Geographic',
-        oceans: 'Océans',
-        osm: 'OpenStreetMap',
-        satellite: 'Image satellitaire',
-        streets: 'Rues',
-        streetsNavigationVector: 'Rues (navigation)',
-        streetsNightVector: 'Rues (nuit)',
-        streetsReliefVector: 'Rues (relief)',
-        terrain: 'Terrain',
-        topo: 'Topographique'
+        landsatShaded: 'Landsat et relief ombragé'
     },
     bookmarks: {
         nullIsland: 'Île Null',

--- a/viewer/js/config/nls/main.js
+++ b/viewer/js/config/nls/main.js
@@ -3,21 +3,8 @@ define({
     root: {
         basemaps: {
             davidRumseyMap1812: 'David Rumsey 1812',
-            darkGrayVector: 'Dark Gray',
             earthAtNight: 'Earth at Night',
-            grayVector: 'Gray',
-            hybrid: 'Hybrid',
-            landsatShaded: 'Landsat Shaded',
-            nationalGeographic: 'Nat Geo',
-            oceans: 'Oceans',
-            osm: 'Open Street Map',
-            satellite: 'Satellite',
-            streets: 'Streets',
-            streetsNavigationVector: 'Streets (Navigation)',
-            streetsNightVector: 'Streets (Night)',
-            streetsReliefVector: 'Streets (Relief)',
-            terrain: 'Terrain',
-            topo: 'Topographic'
+            landsatShaded: 'Landsat Shaded'
         },
         bookmarks: {
             nullIsland: 'Null Island',

--- a/viewer/js/config/nls/pt-br/main.js
+++ b/viewer/js/config/nls/pt-br/main.js
@@ -2,21 +2,8 @@
 define({
     basemaps: {
         davidRumseyMap1812: 'David Rumsey 1812',
-        darkGrayVector: 'Cinzento escuro',
         earthAtNight: 'Terra à noite',
-        grayVector: 'Cinzento',
-        hybrid: 'Híbrido',
-        landsatShaded: 'Landsat sombreado',
-        nationalGeographic: 'National Geographic',
-        oceans: 'Oceanos',
-        osm: 'Open Street Map',
-        satellite: 'Satélite',
-        streets: 'Ruas',
-        streetsNavigationVector: 'Ruas (Navegação)',
-        streetsNightVector: 'Ruas (Nocturno)',
-        streetsReliefVector: 'Ruas (Relevo)',
-        terrain: 'Terreno',
-        topo: 'Topográfico'
+        landsatShaded: 'Landsat sombreado'
     },
     bookmarks: {
         nullIsland: 'Ilha Nula',

--- a/viewer/js/config/nls/pt-pt/main.js
+++ b/viewer/js/config/nls/pt-pt/main.js
@@ -2,21 +2,8 @@
 define({
     basemaps: {
         davidRumseyMap1812: 'David Rumsey 1812',
-        darkGrayVector: 'Cinzento escuro',
         earthAtNight: 'Terra à noite',
-        grayVector: 'Cinzento',
-        hybrid: 'Híbrido',
-        landsatShaded: 'Landsat sombreado',
-        nationalGeographic: 'National Geographic',
-        oceans: 'Oceanos',
-        osm: 'Open Street Map',
-        satellite: 'Satélite',
-        streets: 'Ruas',
-        streetsNavigationVector: 'Ruas (Navegação)',
-        streetsNightVector: 'Ruas (Nocturno)',
-        streetsReliefVector: 'Ruas (Relevo)',
-        terrain: 'Terreno',
-        topo: 'Topográfico'
+        landsatShaded: 'Landsat sombreado'
     },
     bookmarks: {
         nullIsland: 'Ilha Nula',


### PR DESCRIPTION
basemap `mode` is no longer required.
also includes support for all parameters available in the Basemap Gallery widget.
removed i18n for esri basemap to use the esri title. Title can be changed in config.