### PR TITLE
adds 3 new widget types: loading, layout and layer.

### DIFF
--- a/viewer/js/viewer/_ConfigMixin.js
+++ b/viewer/js/viewer/_ConfigMixin.js
@@ -31,6 +31,9 @@ define([
         initConfigSuccess: function (config) {
             this.config = config;
 
+            // in _WidgetsMixin
+            this.createWidgets(['loading']);
+
             if (config.isDebug) {
                 window.app = this; //dev only
             }
@@ -43,6 +46,9 @@ define([
 
             // in _LayoutMixin
             this.initLayout();
+
+            // in _WidgetsMixin
+            this.createWidgets(['layout']);
 
             // in _MapMixin
             this.initMapAsync().then(

--- a/viewer/js/viewer/_MapMixin.js
+++ b/viewer/js/viewer/_MapMixin.js
@@ -194,6 +194,9 @@ define([
             }
 
             if (this.map) {
+                // in _WidgetsMixin
+                this.createWidgets(['map', 'layer']);
+
                 this.map.on('resize', function (evt) {
                     var pnt = evt.target.extent.getCenter();
                     setTimeout(function () {
@@ -205,7 +208,7 @@ define([
                 this.createPanes();
 
                 // in _WidgetsMixin
-                this.initWidgets();
+                this.createWidgets();
             }
 
         },

--- a/viewer/js/viewer/_WidgetsMixin.js
+++ b/viewer/js/viewer/_WidgetsMixin.js
@@ -186,11 +186,6 @@ define([
             return options;
         },
 
-            }
-
-            }
-        },
-
         _createTitlePaneWidget: function (parentId, widgetConfig) {
             var tp,
                 options = lang.mixin({


### PR DESCRIPTION
Also adds 3 new entry points within the Controller to manage when widgets can be created.
Also includes a change to uses the widget's key internally when no id is available. Some Esri widgets cannot have an id passed in the config.

1. `loading` widgets are created as early as possible - just after the config file is loaded. Example might be a [progress bar](https://github.com/thollingshead/dojo-loader-progress).

2. `layout` widgets are created after the layout is built but prior to panes being created and the map is loaded. Example: adjust the layout before any contents are added. Not sure of the usefulness of this type. Open for discussion.

3. `layer` widgets (and `map` widgets)  created after the map and layers have been loaded but prior to panes being created and before other widgets are loaded. Example: setting the [definition expression](https://github.com/cmv/cmv-app/issues/357#issuecomment-249332231) for a feature layer. Similar in concept to a [layer `load` event](https://github.com/cmv/cmv-app/issues/357#issuecomment-71117053) but easier to compartmentalize and manage the code as a widget.