### PR TITLE
Fix StreetView Stylesheet and allow Google API version to be configured.

### DIFF
--- a/viewer/js/gis/dijit/StreetView/css/StreetView.css
+++ b/viewer/js/gis/dijit/StreetView/css/StreetView.css
@@ -2,6 +2,7 @@
     width: 100%;
     height: 250px;
     padding-bottom: 5px;
+    position:  relative;
 }
 
 .gis_StreetView .streetViewButton {

--- a/viewer/js/gis/plugins/Google.js
+++ b/viewer/js/gis/plugins/Google.js
@@ -20,8 +20,6 @@
 	'use strict';
 
 
-	var googleVersion = '3.18';
-
 	var script = null;
 
 	var google = null;
@@ -52,7 +50,7 @@
 
 	GoogleMapsLoader.REGION = null;
 
-	GoogleMapsLoader.VERSION = googleVersion;
+	GoogleMapsLoader.VERSION = '3';
 
 	GoogleMapsLoader.WINDOW_CALLBACK_NAME = '__google_maps_api_provider_initializator__';
 
@@ -108,8 +106,12 @@
 			url += '&libraries=' + GoogleMapsLoader.LIBRARIES.join(',');
 		}
 
+		if (GoogleMapsLoader.VERSION) {
+			url += '&v=' + GoogleMapsLoader.VERSION;
+		}
+
 		if (GoogleMapsLoader.CLIENT) {
-			url += '&client=' + GoogleMapsLoader.CLIENT + '&v=' + GoogleMapsLoader.VERSION;
+			url += '&client=' + GoogleMapsLoader.CLIENT;
 		}
 
 		if (GoogleMapsLoader.CHANNEL) {


### PR DESCRIPTION
Add position:relative to the widget's container div so the absolutely positioned button doesn't appear at the top of the page.
Allow the version of the Google API to be set in the app configuration file.