### PR TITLE
make identify listen for new layer contol layer adds

### DIFF
--- a/viewer/js/gis/dijit/Identify.js
+++ b/viewer/js/gis/dijit/Identify.js
@@ -98,6 +98,7 @@ define([
         /**
          * handles an array of layerInfos to call addLayerInfo for each layerInfo
          * @param {Array<layerInfo>} layerInfos The array of layer infos
+         * @returns {undefined}
          */
         addLayerInfos: function (layerInfos) {
             array.forEach(layerInfos, lang.hitch(this, 'addLayerInfo'));
@@ -106,6 +107,7 @@ define([
          * Initializes an infoTemplate on a layerInfo.layer object if it doesn't
          * exist already.
          * @param {object} layerInfo A cmv layerInfo object that contains a layer property
+         * @return {undefined}
          */
         addLayerInfo: function (layerInfo) {
             var lyrId = layerInfo.layer.id, layer = this.map.getLayer(lyrId), infoTemplate;


### PR DESCRIPTION
Moved the layerinfos init code into its own function `initLayerInfos` so we can call this when the topic is published that adds new layers to the layer control. 

One example of using this would be [in a custom layer generating widget](https://github.com/roemhildtg/cmv-widgets/blob/master/widgets/LabelLayer.js#L197-L212):

```javascript
                layer = new FeatureLayer(serviceURL, layerOptions);
                this._labelLayers[layerId] = {
                    layer: layer,
                    iconNode: this.activeLayer.iconNode
                };
                this.map.addLayer(layer);

                // notify layer control
                // wait for async layer loads
                layer.on('load', lang.hitch(this, function() {
                    topic.publish('identify/addLayerInfos', [{
                        type: 'feature',
                        layer: layer,
                        title: title
                    }]);
                }))
```

I realize this is using a layerControl topic but it makes more sense to use the existing topic than register a new one just for identify widget. It seems silly to have any widget that adds a layer publish two topics (or more) if we're just adding a new layer to the app. 

Perhaps we should make a more generic layer adding topic.