### PR TITLE
Enable identify formatters for feature layers.

### DIFF
--- a/viewer/js/gis/dijit/Identify.js
+++ b/viewer/js/gis/dijit/Identify.js
@@ -363,7 +363,7 @@ define([
             if (feature && infoTemplate && infoTemplate.info) {
                 array.forEach(infoTemplate.info.fieldInfos, function (info) {
                     if (typeof info.formatter === 'function') {
-                        feature.attributes[info.fieldName] = info.formatter(feature.attributes[info.fieldName], feature.attributes, feature.geometry);
+                        feature.attributes[info.fieldName] = info.formatter(feature.attributes[info.fieldName], feature.attributes, lang.clone(feature.geometry));
                     }
                 });
             }

--- a/viewer/js/gis/dijit/Identify.js
+++ b/viewer/js/gis/dijit/Identify.js
@@ -126,6 +126,13 @@ define([
                             infoTemplate = this.getInfoTemplate(layer, layer.layerId);
                             if (infoTemplate) {
                                 layer.setInfoTemplate(infoTemplate);
+                                var fieldInfos = infoTemplate.info.fieldInfos;
+                                var formatters = array.filter(fieldInfos, function (info) {
+                                    return (info.formatter);
+                                });
+                                if (formatters.length > 0) {
+                                    layer.on('graphic-draw', lang.hitch(this, 'getFormattedFeature', layer.infoTemplate));
+                                }
                                 return;
                             }
                         }
@@ -343,18 +350,23 @@ define([
                             return;
                         }
                     }
-                    var feature = this.getFormattedFeature(result.feature);
+                    var feature = this.getFormattedFeature(result.feature.infoTemplate, result.feature);
                     fSet.push(feature);
                 }, this);
             }, this);
             this.map.infoWindow.setFeatures(fSet);
         },
-        getFormattedFeature: function (feature) {
-            array.forEach(feature.infoTemplate.info.fieldInfos, function (info) {
-                if (typeof info.formatter === 'function') {
-                    feature.attributes[info.fieldName] = info.formatter(feature.attributes[info.fieldName], feature.attributes);
-                }
-            });
+        getFormattedFeature: function (infoTemplate, feature) {
+            if (feature.graphic) {
+                feature = feature.graphic;
+            }
+            if (feature && infoTemplate && infoTemplate.info) {
+                array.forEach(infoTemplate.info.fieldInfos, function (info) {
+                    if (typeof info.formatter === 'function') {
+                        feature.attributes[info.fieldName] = info.formatter(feature.attributes[info.fieldName], feature.attributes, feature.geometry);
+                    }
+                });
+            }
             return feature;
         },
         identifyError: function (err) {


### PR DESCRIPTION
Not sure I am formatting the attributes at the right place for all scenarios. Improvements or suggestions welcome. This modifies the original attributes which is a negative side effect previously noted in #650 

Also includes passing the feature geometry to the formatter. This allows for calculation of area/length/position/etc.

Example formatter for acres:
(assumes geometryEngine included in define statement)
```
acres: function (value, attributes, geometry) {
    if (geometry && geometry.type === 'polygon') {
        return geometryEngine.geodesicArea(geometry, 'acres');
    }
    return '';
},
```

Example fieldInfo:
```
{
    fieldName: 'acres',
    label: 'Acres',
    visible: true,
    format: {places: 2, digitSeparator: true},
    formatter: formatters.acres
},
```

More formatter examples:
```
latlng: function (value, attributes, geometry) {
    if (geometry && geometry.type === 'point' && geometry.spatialReference.wkid === 102100) {
        var pt = webMercatorUtils.webMercatorToGeographic(geometry);
        var lat = number.format(pt.y, {
            places: 6
        });
        var lng = number.format(pt.x, {
            places: 6
        });
        return 'Latitude: ' + lat + '<br/>Longitude: ' + lng;
    }
    return '';
},

latitude: function (value, attributes, geometry) {
    if (geometry && geometry.type === 'point' && geometry.spatialReference.wkid === 102100) {
        var pt = webMercatorUtils.webMercatorToGeographic(geometry);
        return pt.y;
    }
    return '';
},

longitude: function (value, attributes, geometry) {
    if (geometry && geometry.type === 'point' && geometry.spatialReference.wkid === 102100) {
        var pt = webMercatorUtils.webMercatorToGeographic(geometry);
        return pt.x;
    }
    return '';
},

length: function (value, attributes, geometry) {
    if (geometry && geometry.type === 'polyline') {
        return geometryEngine.geodesicLength(geometry, 'feet');
    }
    return '';
},
```