### PR TITLE
FIX: update legend when maps `update-end` event is fired

### DIFF
--- a/viewer/js/config/viewer.js
+++ b/viewer/js/config/viewer.js
@@ -397,7 +397,7 @@ define([
                 include: true,
                 id: 'legend',
                 type: 'titlePane',
-                path: 'esri/dijit/Legend',
+                path: 'gis/dijit/Legend',
                 title: i18n.viewer.widgets.legend,
                 open: false,
                 position: 1,

--- a/viewer/js/gis/dijit/Legend.js
+++ b/viewer/js/gis/dijit/Legend.js
@@ -1,0 +1,31 @@
+define([
+    'dojo/_base/declare',
+    'dijit/_WidgetBase',
+    'dojo/_base/lang',
+    'esri/dijit/Legend'
+], function (
+    declare,
+    _WidgetBase,
+    lang,
+    Legend
+) {
+    return declare([_WidgetBase], {
+        startup: function () {
+            this.inherited(arguments);
+
+            this.legend = new Legend({
+                arrangement: this.arrangement || Legend.ALIGN_LEFT,
+                autoUpdate: this.autoUpdate || true,
+                id: this.id + '_legend',
+                layerInfos: this.layerInfos,
+                map: this.map,
+                respectCurrentMapScale: this.respectCurrentMapScale || true
+            }, this.domNode);
+            this.legend.startup();
+
+            this.map.on('update-end', lang.hitch(this, function () {
+                this.legend.refresh();
+            }));
+        }
+    });
+});


### PR DESCRIPTION
 - adds new gis/dijit/Legend widget from https://github.com/cmv/cmv-app/issues/659
 - fixes https://github.com/cmv/cmv-app/issues/340
 - fixes https://github.com/cmv/cmv-app/issues/294