### PR TITLE
Use inherited mixins

### DIFF
--- a/viewer/js/config/app.js
+++ b/viewer/js/config/app.js
@@ -51,10 +51,10 @@
     ) {
         var App = declare([
             _LayoutMixin,
-            _MapMixin,
             _WidgetsMixin,
 
             _WebMapMixin,
+            _MapMixin,
             _ConfigMixin,
             _ControllerBase
         ]);

--- a/viewer/js/config/app.js
+++ b/viewer/js/config/app.js
@@ -49,15 +49,16 @@
         //_MyCustomMixin
 
     ) {
-        var controller = new (declare([
-            _ControllerBase,
-            _ConfigMixin,
+        var App = declare([
             _LayoutMixin,
             _MapMixin,
             _WidgetsMixin,
 
-            _WebMapMixin
-        ]))();
-        controller.startup();
+            _WebMapMixin,
+            _ConfigMixin,
+            _ControllerBase
+        ]);
+        var app = new App();
+        app.startup();
     });
 })();

--- a/viewer/js/config/app.js
+++ b/viewer/js/config/app.js
@@ -50,12 +50,24 @@
 
     ) {
         var App = declare([
+
+            // add custom mixins here...note order may be important and
+            // overriding certain methods incorrectly may break the app
+            // First on the list are last called last, for instance the startup
+            // method on _ControllerBase is called FIRST, and _LayoutMixin is called LAST
+            // for the most part they are interchangeable, except _ConfigMixin
+            // and _ControllerBase
+            //
             _LayoutMixin,
             _WidgetsMixin,
-
-            _WebMapMixin,
+            // _WebMapMixin,
             _MapMixin,
+
+            // configMixin should be right before _ControllerBase so it is
+            // called first to initialize the config object
             _ConfigMixin,
+
+            // controller base needs to be last
             _ControllerBase
         ]);
         var app = new App();

--- a/viewer/js/config/app.js
+++ b/viewer/js/config/app.js
@@ -31,9 +31,9 @@
         'viewer/_ConfigMixin', // manage the Configuration
         'viewer/_LayoutMixin', // build and manage the Page Layout and User Interface
         'viewer/_MapMixin', // build and manage the Map
-        'viewer/_WidgetsMixin', // build and manage the Widgets
+        'viewer/_WidgetsMixin' // build and manage the Widgets
 
-        'viewer/_WebMapMixin' // for WebMaps
+        // 'viewer/_WebMapMixin' // for WebMaps
         //'config/_customMixin'
 
     ], function (
@@ -45,7 +45,7 @@
         _MapMixin,
         _WidgetsMixin,
 
-        _WebMapMixin
+        // _WebMapMixin
         //_MyCustomMixin
 
     ) {

--- a/viewer/js/config/viewer.js
+++ b/viewer/js/config/viewer.js
@@ -78,7 +78,7 @@ define([
             sliderStyle: 'small'
         },
 
-        //webMapId: 'ef9c7fbda731474d98647bebb4b33c20',  // High Cost Mortgage
+        webMapId: '880a967872114b44a63c207df10e0a75',  // High Cost Mortgage
         // webMapOptions: {},
 
         // panes: {
@@ -273,6 +273,16 @@ define([
         }],
         // set include:true to load. For titlePane type set position the the desired order in the sidebar
         widgets: {
+            // a widget that loads and runs before the app
+            // loader: {
+            //     type: 'loading',
+            //     path: 'dijit/_WidgetBase',
+            //     options: {
+            //         constructor: function () {
+            //             alert('Preload!');
+            //         }
+            //     }
+            // },
             growler: {
                 include: true,
                 id: 'growler',

--- a/viewer/js/viewer/_ConfigMixin.js
+++ b/viewer/js/viewer/_ConfigMixin.js
@@ -9,6 +9,13 @@ define([
 ) {
 
     return declare(null, {
+        startup: function () {
+            this.inherited(arguments);
+            this.initConfigAsync().then(
+                lang.hitch(this, 'initConfigSuccess'),
+                lang.hitch(this, 'initConfigError')
+            );
+        },
 
         initConfigAsync: function () {
             var returnDeferred = new Deferred();
@@ -30,10 +37,6 @@ define([
 
         initConfigSuccess: function (config) {
             this.config = config;
-
-            // in _WidgetsMixin
-            this.createWidgets(['loading']);
-
             if (config.isDebug) {
                 window.app = this; //dev only
             }
@@ -44,17 +47,7 @@ define([
                 defaultMode: config.defaultMapClickMode
             };
 
-            // in _LayoutMixin
-            this.initLayout();
-
-            // in _WidgetsMixin
-            this.createWidgets(['layout']);
-
-            // in _MapMixin
-            this.initMapAsync().then(
-                lang.hitch(this, 'initMapComplete'),
-                lang.hitch(this, 'initMapError')
-            );
+            this.configDeferred.resolve(config);
         },
 
         initConfigError: function (err) {

--- a/viewer/js/viewer/_ControllerBase.js
+++ b/viewer/js/viewer/_ControllerBase.js
@@ -1,21 +1,35 @@
 /*eslint no-console: 0*/
 define([
     'dojo/_base/declare',
-    'dojo/_base/lang'
+    'dojo/_base/lang',
+    'dojo/Deferred'
 ], function (
     declare,
-    lang
+    lang,
+    Deferred
 ) {
     return declare(null, {
+        init: function () {
+
+            // create a set of deferreds that can be resolved by mixins
+            // other mixins can also create deferreds in their relevent constructors
+            this.configDeferred = new Deferred();
+
+            this.inherited(arguments);
+        },
 
         startup: function () {
+            this.init();
+            this.mapDeferred.then(function () {
+                console.log(' map deferred');
+            });
+            this.configDeferred.then(function () {
+                console.log(' config deferred');
+            });
+            this.layoutDeferred.then(function () {
+                console.log(' layout deferred');
+            });
             this.inherited(arguments);
-
-            // in _ConfigMixin
-            this.initConfigAsync().then(
-                lang.hitch(this, 'initConfigSuccess'),
-                lang.hitch(this, 'initConfigError')
-            );
         },
 
         //centralized error handler

--- a/viewer/js/viewer/_ControllerBase.js
+++ b/viewer/js/viewer/_ControllerBase.js
@@ -4,38 +4,74 @@ define([
     'dojo/_base/lang',
     'dojo/Deferred'
 ], function (
-    declare,
-    lang,
-    Deferred
+    declare, lang, Deferred
 ) {
     return declare(null, {
-        init: function () {
-
-            // create a set of deferreds that can be resolved by mixins
-            // other mixins can also create deferreds in their relevent constructors
-            this.configDeferred = new Deferred();
-
-            this.inherited(arguments);
+        /**
+         * A method run before anything else, can be inherited by mixins to
+         * load and process the config sync or async
+         * @return {undefined | Deferred} If the operation is async it should return
+         * a deferred, otherwise it should return the value of `this.inherited(arguments)`
+         */
+        loadConfig: function () {
+            return this.inherited(arguments);
         },
+        /**
+         * A method run after the config is loaded but before startup is called
+         * on mixins
+         * @return {undefined | Deferred} If the operation is async it should return
+         * a deferred, otherwise it should return the value of `this.inherited(arguments)`
+         */
+        preStartup: function () {
+            return this.inherited(arguments);
+        },
+        /**
+         * executes an array of asynchronous methods synchronously
+         * @param  {Array<function>} methods  The array of functions to execute
+         * @param {Deferred} deferred A deferred created inside the method and resolved once all methods are complete
+         * @return {Deferred}          A deferred resolved once all methods are executed
+         */
+        executeSync: function (methods, deferred) {
+            deferred = deferred || new Deferred();
 
+            // if our list is empty, resolve the deferred and quit
+            if (!methods || !methods.length) {
+                deferred.resolve();
+                return deferred;
+            }
+
+            // execute and remove the method from the list
+            var result = lang.hitch(this, methods.splice(0, 1)[0])();
+
+            // execute our next function once this one completes
+            if (result) {
+                result.then(lang.hitch(this, 'executeSync', methods, deferred));
+            } else {
+                this.executeSync(methods, deferred);
+            }
+            return deferred;
+
+        },
         startup: function () {
-            this.init();
-            this.mapDeferred.then(function () {
-                console.log(' map deferred');
-            });
-            this.configDeferred.then(function () {
-                console.log(' config deferred');
-            });
-            this.layoutDeferred.then(function () {
-                console.log(' layout deferred');
-            });
-            this.inherited(arguments);
+
+            var inherited = this.getInherited(arguments);
+            this.executeSync([
+                this.loadConfig,
+                this.preStartup
+            ]).then(lang.hitch(this, function () {
+                console.log(this);
+
+                // start up the mixin chain
+                inherited.apply(this);
+            }));
+
+
         },
 
         //centralized error handler
         handleError: function (options) {
             if (this.config.isDebug) {
-                if (typeof (console) === 'object') {
+                if (typeof(console) === 'object') {
                     for (var option in options) {
                         if (options.hasOwnProperty(option)) {
                             console.log(option, options[option]);

--- a/viewer/js/viewer/_LayoutMixin.js
+++ b/viewer/js/viewer/_LayoutMixin.js
@@ -11,6 +11,8 @@ define([
     'dojo/dom-class',
     'dojo/dom-geometry',
     'dojo/sniff',
+    'dojo/Deferred',
+    'dojo/promise/all',
 
     'put-selector',
 
@@ -33,6 +35,8 @@ define([
     domClass,
     domGeom,
     has,
+    Deferred,
+    promiseAll,
 
     put,
 
@@ -61,6 +65,14 @@ define([
             }
         },
         collapseButtons: {},
+        init: function () {
+            this.inherited(arguments);
+            this.layoutDeferred = new Deferred();
+        },
+        startup: function () {
+            this.inherited(arguments);
+            promiseAll([this.configDeferred]).then(lang.hitch(this, 'initLayout'));
+        },
 
         initLayout: function () {
             this.config.layout = this.config.layout || {};
@@ -69,6 +81,9 @@ define([
             this.addTitles();
             this.detectTouchDevices();
             this.initPanes();
+
+            // resolve the layout deferred
+            this.layoutDeferred.resolve();
         },
 
         // add topics for subscribing and publishing

--- a/viewer/js/viewer/_LayoutMixin.js
+++ b/viewer/js/viewer/_LayoutMixin.js
@@ -12,7 +12,6 @@ define([
     'dojo/dom-geometry',
     'dojo/sniff',
     'dojo/Deferred',
-    'dojo/promise/all',
 
     'put-selector',
 
@@ -36,7 +35,6 @@ define([
     domGeom,
     has,
     Deferred,
-    promiseAll,
 
     put,
 

--- a/viewer/js/viewer/_LayoutMixin.js
+++ b/viewer/js/viewer/_LayoutMixin.js
@@ -65,16 +65,12 @@ define([
             }
         },
         collapseButtons: {},
-        init: function () {
-            this.inherited(arguments);
+        preStartup: function () {
             this.layoutDeferred = new Deferred();
-        },
-        startup: function () {
-            this.inherited(arguments);
-            promiseAll([this.configDeferred]).then(lang.hitch(this, 'initLayout'));
+            return this.inherited(arguments);
         },
 
-        initLayout: function () {
+        startup: function () {
             this.config.layout = this.config.layout || {};
 
             this.addTopics();
@@ -84,6 +80,7 @@ define([
 
             // resolve the layout deferred
             this.layoutDeferred.resolve();
+            this.inherited(arguments);
         },
 
         // add topics for subscribing and publishing
@@ -186,7 +183,7 @@ define([
                     panes[key] = lang.mixin(this.defaultPanes[key], panes[key]);
                 }
             }
-                        // where to place the buttons
+            // where to place the buttons
             // either the center map pane or the outer pane?
             this.collapseButtonsPane = this.config.collapseButtonsPane || 'outer';
 
@@ -266,7 +263,10 @@ define([
                     }
 
                     if (!suppressEvent) {
-                        topic.publish('viewer/onTogglePane', {pane: id, show: show});
+                        topic.publish('viewer/onTogglePane', {
+                            pane: id,
+                            show: show
+                        });
                     }
                 }
             }

--- a/viewer/js/viewer/_MapMixin.js
+++ b/viewer/js/viewer/_MapMixin.js
@@ -5,7 +5,6 @@ define([
     'dojo/dom',
     'dojo/_base/array',
     'dojo/Deferred',
-    'dojo/promise/all',
 
     'esri/map',
 
@@ -18,7 +17,6 @@ define([
     dom,
     array,
     Deferred,
-    promiseAll,
 
     Map
 ) {

--- a/viewer/js/viewer/_MapMixin.js
+++ b/viewer/js/viewer/_MapMixin.js
@@ -55,7 +55,6 @@ define([
             }
 
             // otherwise we can create the map
-            var returnWarnings = [];
             var mapDeferred = new Deferred(),
                 container = dom.byId(this.config.layout.map) || 'mapCenter';
 
@@ -65,8 +64,9 @@ define([
             var wait = this.inherited(arguments);
             if (wait) {
                 wait.then(function (warnings) {
-                    // are warnings passed?
-                    // returnWarnings.push(warnings);
+                    if (warnings) {
+                        returnWarnings = returnWarnings.concat(warnings);
+                    }
                     mapDeferred.resolve(returnWarnings);
                 });
             } else {

--- a/viewer/js/viewer/_MapMixin.js
+++ b/viewer/js/viewer/_MapMixin.js
@@ -62,7 +62,7 @@ define([
             this.map = new Map(container, this.config.mapOptions);
 
             // let some other mixins modify or add map items async
-            wait = this.inherited(arguments) || wait;
+            var wait = this.inherited(arguments);
             if (wait) {
                 wait.then(function (warnings) {
                     // are warnings passed?

--- a/viewer/js/viewer/_MapMixin.js
+++ b/viewer/js/viewer/_MapMixin.js
@@ -39,19 +39,31 @@ define([
             var returnDeferred = new Deferred();
             var returnWarnings = [];
 
-            this._createMap(returnWarnings).then(
+            this.createMap(returnWarnings).then(
                 lang.hitch(this, '_createMapResult', returnDeferred, returnWarnings)
             );
             returnDeferred.then(lang.hitch(this, 'initMapComplete'));
             return returnDeferred;
         },
 
-        _createMap: function (returnWarnings) {
+        createMap: function (returnWarnings) {
+            var returnWarnings = [];
             var mapDeferred = new Deferred(),
                 container = dom.byId(this.config.layout.map) || 'mapCenter';
 
             this.map = new Map(container, this.config.mapOptions);
-            mapDeferred.resolve(returnWarnings);
+
+            // let some other mixins modify or add map items async
+            var wait = this.inherited(arguments);
+            if (wait) {
+                wait.then(function (warnings) {
+                    // are warnings passed?
+                    // returnWarnings.push(warnings);
+                    mapDeferred.resolve(returnWarnings);
+                });
+            } else {
+                mapDeferred.resolve(returnWarnings);
+            }
             return mapDeferred;
         },
 

--- a/viewer/js/viewer/_MapMixin.js
+++ b/viewer/js/viewer/_MapMixin.js
@@ -5,6 +5,7 @@ define([
     'dojo/dom',
     'dojo/_base/array',
     'dojo/Deferred',
+    'dojo/promise/all',
 
     'esri/map',
 
@@ -17,11 +18,22 @@ define([
     dom,
     array,
     Deferred,
+    promiseAll,
 
     Map
 ) {
 
     return declare(null, {
+
+        init: function () {
+            this.inherited(arguments);
+            this.mapDeferred = new Deferred();
+        },
+
+        startup: function () {
+            this.inherited(arguments);
+            promiseAll([this.configDeferred, this.layoutDeferred]).then(lang.hitch(this, 'initMapAsync'));
+        },
 
         initMapAsync: function () {
             var returnDeferred = new Deferred();
@@ -39,7 +51,7 @@ define([
 
             if (this.config.webMapId) {
                 if (this._initWebMap) {
-                    mapDeferred = this._initWebMap(this.config.webMapId, container, this.config.webMapOptions);
+                    // mapDeferred = this._initWebMap(this.config.webMapId, container, this.config.webMapOptions);
                 } else {
                     returnWarnings.push('The "_WebMapMixin" Controller Mixin is required to use a webmap');
                     mapDeferred.resolve(returnWarnings);
@@ -195,7 +207,7 @@ define([
 
             if (this.map) {
                 // in _WidgetsMixin
-                this.createWidgets(['map', 'layer']);
+                // this.createWidgets(['map', 'layer']);
 
                 this.map.on('resize', function (evt) {
                     var pnt = evt.target.extent.getCenter();
@@ -205,10 +217,11 @@ define([
                 });
 
                 // in _LayoutsMixin
-                this.createPanes();
+                // this.createPanes();
 
                 // in _WidgetsMixin
-                this.createWidgets();
+                // this.createWidgets();
+                this.mapDeferred.resolve(this.map);
             }
 
         },

--- a/viewer/js/viewer/_MapMixin.js
+++ b/viewer/js/viewer/_MapMixin.js
@@ -47,6 +47,14 @@ define([
         },
 
         createMap: function (returnWarnings) {
+
+            // mixins override the default createMap method and return a deferred
+            var result = this.inherited(arguments);
+            if (result) {
+                return result;
+            }
+
+            // otherwise we can create the map
             var returnWarnings = [];
             var mapDeferred = new Deferred(),
                 container = dom.byId(this.config.layout.map) || 'mapCenter';
@@ -54,7 +62,7 @@ define([
             this.map = new Map(container, this.config.mapOptions);
 
             // let some other mixins modify or add map items async
-            var wait = this.inherited(arguments);
+            wait = this.inherited(arguments) || wait;
             if (wait) {
                 wait.then(function (warnings) {
                     // are warnings passed?

--- a/viewer/js/viewer/_WebMapMixin.js
+++ b/viewer/js/viewer/_WebMapMixin.js
@@ -25,10 +25,10 @@ define([
     return declare(null, {
         startup: function () {
             this.inherited(arguments);
-            this.mapDeferred.then(lang.hitch(this, '_initWebMap'));
+            // this.mapDeferred.then(lang.hitch(this, '_initWebMap'));
         },
 
-        _initWebMap: function () {
+        createMap: function () {
             var webMapOptions = this.config.webMapOptions || {};
             if (!webMapOptions.mapOptions && this.config.mapOptions) {
                 webMapOptions.mapOptions = this.config.mapOptions;

--- a/viewer/js/viewer/_WebMapMixin.js
+++ b/viewer/js/viewer/_WebMapMixin.js
@@ -29,6 +29,7 @@ define([
         },
 
         createMap: function () {
+            console.log('web map mixin');
             var webMapOptions = this.config.webMapOptions || {};
             if (!webMapOptions.mapOptions && this.config.mapOptions) {
                 webMapOptions.mapOptions = this.config.mapOptions;

--- a/viewer/js/viewer/_WebMapMixin.js
+++ b/viewer/js/viewer/_WebMapMixin.js
@@ -3,6 +3,7 @@ define([
     'dojo/_base/lang',
     'dojo/_base/array',
     'dojo/promise/all',
+    'dojo/dom',
 
     'esri/arcgis/utils',
     'esri/units',
@@ -14,6 +15,7 @@ define([
     lang,
     array,
     promiseAll,
+    dom,
 
     arcgisUtils,
     units,
@@ -23,7 +25,7 @@ define([
     return declare(null, {
         startup: function () {
             this.inherited(arguments);
-            promiseAll([this.configDeferred, this.mapDeferred]).then(lang.hitch(this, '_initWebMap'));
+            this.mapDeferred.then(lang.hitch(this, '_initWebMap'));
         },
 
         _initWebMap: function () {

--- a/viewer/js/viewer/_WebMapMixin.js
+++ b/viewer/js/viewer/_WebMapMixin.js
@@ -2,7 +2,6 @@ define([
     'dojo/_base/declare',
     'dojo/_base/lang',
     'dojo/_base/array',
-    'dojo/promise/all',
     'dojo/dom',
 
     'esri/arcgis/utils',
@@ -14,7 +13,6 @@ define([
     declare,
     lang,
     array,
-    promiseAll,
     dom,
 
     arcgisUtils,

--- a/viewer/js/viewer/_WebMapMixin.js
+++ b/viewer/js/viewer/_WebMapMixin.js
@@ -29,7 +29,6 @@ define([
         },
 
         createMap: function () {
-            console.log('web map mixin');
             var webMapOptions = this.config.webMapOptions || {};
             if (!webMapOptions.mapOptions && this.config.mapOptions) {
                 webMapOptions.mapOptions = this.config.mapOptions;

--- a/viewer/js/viewer/_WebMapMixin.js
+++ b/viewer/js/viewer/_WebMapMixin.js
@@ -2,6 +2,7 @@ define([
     'dojo/_base/declare',
     'dojo/_base/lang',
     'dojo/_base/array',
+    'dojo/promise/all',
 
     'esri/arcgis/utils',
     'esri/units',
@@ -12,6 +13,7 @@ define([
     declare,
     lang,
     array,
+    promiseAll,
 
     arcgisUtils,
     units,
@@ -19,14 +21,19 @@ define([
     i18n
 ) {
     return declare(null, {
+        startup: function () {
+            this.inherited(arguments);
+            promiseAll([this.configDeferred, this.mapDeferred]).then(lang.hitch(this, '_initWebMap'));
+        },
 
-        _initWebMap: function (webMapId, container, webMapOptions) {
-            webMapOptions = webMapOptions || {};
+        _initWebMap: function () {
+            var webMapOptions = this.config.webMapOptions || {};
             if (!webMapOptions.mapOptions && this.config.mapOptions) {
                 webMapOptions.mapOptions = this.config.mapOptions;
             }
+            var container = dom.byId(this.config.layout.map) || 'mapCenter';
 
-            var mapDeferred = arcgisUtils.createMap(webMapId, container, webMapOptions);
+            var mapDeferred = arcgisUtils.createMap(this.config.webMapId, container, webMapOptions);
             mapDeferred.then(lang.hitch(this, function (response) {
                 this.webMap = {
                     clickEventHandle: response.clickEventHandle,

--- a/viewer/js/viewer/_WidgetsMixin.js
+++ b/viewer/js/viewer/_WidgetsMixin.js
@@ -34,6 +34,21 @@ define([
 
         widgets: {},
         widgetTypes: ['titlePane', 'contentPane', 'floating', 'domNode', 'invisible', 'map', 'layer', 'layout', 'loading'],
+        init: function () {
+            this.inherited(arguments);
+            this.configDeferred.then(lang.hitch(this, 'createWidgets', ['loading']));
+        },
+        startup: function () {
+            this.inherited(arguments);
+            this.configDeferred.then(lang.hitch(this, function () {
+                if (this.mapDeferred) {
+                    this.mapDeferred.then(lang.hitch(this, 'createWidgets', ['map', 'layer']));
+                }
+                if (this.layoutDeferred) {
+                    this.layoutDeferred.then(lang.hitch(this, 'createWidgets', ['titlePane', 'contentPane', 'floating', 'domNode', 'invisible', 'layout']));
+                }
+            }));
+        },
 
         createWidgets: function (widgetTypes) {
             var widgets = [],
@@ -45,7 +60,7 @@ define([
                     var widget = lang.clone(this.config.widgets[key]);
                     widget.widgetKey = widget.widgetKey || widget.id || key;
                     if (widget.include && (!this.widgets[widget.widgetKey]) && (array.indexOf(widgetTypes, widget.type) >= 0)) {
-                        widget.position = (typeof (widget.position) !== 'undefined') ? widget.position : 10000;
+                        widget.position = (typeof(widget.position) !== 'undefined') ? widget.position : 10000;
                         if ((widget.type === 'titlePane' || widget.type === 'contentPane') && !widget.placeAt) {
                             widget.placeAt = 'left';
                         }
@@ -122,7 +137,7 @@ define([
             }
 
             // 2 ways to use require to accommodate widgets that may have an optional separate configuration file
-            if (typeof (widgetConfig.options) === 'string') {
+            if (typeof(widgetConfig.options) === 'string') {
                 require([widgetConfig.options, widgetConfig.path], lang.hitch(this, 'createWidget', widgetConfig));
             } else {
                 require([widgetConfig.path], lang.hitch(this, 'createWidget', widgetConfig, widgetConfig.options));
@@ -220,7 +235,7 @@ define([
                 options.id = parentId;
             }
             var placeAt = widgetConfig.placeAt;
-            if (typeof (placeAt) === 'string') {
+            if (typeof(placeAt) === 'string') {
                 placeAt = this.panes[placeAt];
             }
             if (!placeAt) {
@@ -261,7 +276,7 @@ define([
             var placeAt = widgetConfig.placeAt;
             if (!placeAt) {
                 placeAt = this.panes.left;
-            } else if (typeof (placeAt) === 'string') {
+            } else if (typeof(placeAt) === 'string') {
                 placeAt = this.panes[placeAt];
             }
             if (placeAt) {

--- a/viewer/js/viewer/_WidgetsMixin.js
+++ b/viewer/js/viewer/_WidgetsMixin.js
@@ -64,9 +64,7 @@ define([
             }
             if (this.layoutDeferred) {
                 promiseAll([this.mapDeferred, this.layoutDeferred])
-                    .then(lang.hitch(this,
-                        'createWidgets', ['titlePane', 'contentPane', 'floating', 'domNode', 'invisible', 'layout']
-                    ));
+                    .then(lang.hitch(this, 'createWidgets'));
             }
         },
 
@@ -139,7 +137,7 @@ define([
                     source: 'Controller',
                     error: 'Widget type "' + widgetConfig.type + '" (' + widgetConfig.title + ') at position ' + position + ' is not supported.'
                 });
-                return;
+                return null;
             }
 
             if (position) {

--- a/viewer/js/viewer/_WidgetsMixin.js
+++ b/viewer/js/viewer/_WidgetsMixin.js
@@ -64,7 +64,7 @@ define([
             }
             if (this.layoutDeferred) {
                 promiseAll([this.mapDeferred, this.layoutDeferred])
-                    .then(lang.hitch(this, 'createWidgets'));
+                    .then(lang.hitch(this, 'createWidgets', null));
             }
         },
 


### PR DESCRIPTION
 - make mixins less dependent on each other by implementing common methods and `this.inherited`
    - `loadConfig` - a method that can load and modify the config object before the app begins loading 
    - `postConfig` - a method that can initialize app variables and perform any necessary operations after the config is loaded and processed, but before startup happens
    - `startup` - a method that starts the app layout, map, widgets, etc