### PR TITLE
make default config path configureable

### DIFF
--- a/viewer/js/viewer/_ConfigMixin.js
+++ b/viewer/js/viewer/_ConfigMixin.js
@@ -9,6 +9,10 @@ define([
 ) {
 
     return declare(null, {
+
+        // the default name of the config file to load if ?config=configName
+        // is not specified
+        defaultConfig: 'viewer',
         loadConfig: function (wait) {
 
             // this will be used to make any inherited methods 'wait'
@@ -49,7 +53,7 @@ define([
         initConfigAsync: function () {
             var returnDeferred = new Deferred();
             // get the config file from the url if present
-            var file = 'config/viewer',
+            var file = 'config/' + this.defaultConfig,
                 s = window.location.search,
                 q = s.match(/config=([^&]*)/i);
             if (q && q.length > 0) {

--- a/viewer/js/viewer/_ControllerBase.js
+++ b/viewer/js/viewer/_ControllerBase.js
@@ -9,6 +9,15 @@ define([
     return declare(null, {
 
         /**
+         * Mixes in this apps properties with the passed arguments
+         * @param  {Object} args The properties to mixin
+         * @return {undefined}
+         */
+        constructor: function (args) {
+            lang.mixin(this, args);
+        },
+
+        /**
          * A method run before anything else, can be inherited by mixins to
          * load and process the config sync or async
          * @return {undefined | Deferred} If the operation is async it should return


### PR DESCRIPTION
In `app.js` you can do something like this:

```javascript
var app = new App({
    configPath: 'myConfig/path',
    defaultConfig: 'explorerApp'
});

Rather than having to write a custom mixin just to change the path to the config folder. 