### PR TITLE
Revert "Added 'draggable' property to identify config object"

### DIFF
--- a/viewer/js/config/identify.js
+++ b/viewer/js/config/identify.js
@@ -4,7 +4,6 @@ define({
 	mapRightClickMenu: true,
 	identifyLayerInfos: true,
 	identifyTolerance: 5,
-	draggable: false,
 
 	// config object definition:
 	//	{<layer id>:{


### PR DESCRIPTION
This reverts commit 5bd6769f4366560f1b021be1e0b5ced0b04b1ec9.
This commit was merged into the wrong branch.
This will allow us to merge develop branch in preparation of version 2.0.0-beta.1 release.