### PR TITLE
Basic Config Switcher Widget

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -31,6 +31,10 @@
                 </div>
             </div>
             <div class="search">
+                <div id='configSwitcher'>
+                </div>
+            </div>
+            <div class="search">
                 <div id='geocodeDijit'>
                 </div>
             </div>

--- a/viewer/js/config/viewer-alternative.js
+++ b/viewer/js/config/viewer-alternative.js
@@ -1,0 +1,50 @@
+define([
+    'config/viewer'
+], function (config) {
+    var widgets = config.widgets;
+    config.widgets = {
+        growler: widgets.growler,
+        search: widgets.search,
+        basemaps: widgets.basemaps,
+        mapInfo: widgets.mapInfo,
+        scalebar: widgets.scalebar,
+        locateButton: widgets.locateButton,
+        overviewMap: widgets.overviewMap,
+        homeButton: widgets.homeButton,
+        legend: widgets.legend,
+        layerControl: widgets.layerControl,
+        locale: widgets.locale,
+        help: widgets.help,
+        configSwitch: widgets.configSwitch
+    };
+    /*
+        growler: widgets.growler,
+        search: widgets.search,
+        basemaps: widgets.basemaps,
+        identify: widgets.identify,
+        mapInfo: widgets.mapInfo,
+        scalebar: widgets.scalebar,
+        locateButton: widgets.locateButton,
+        overviewMap: widgets.overviewMap,
+        homeButton: widgets.homeButton,
+        legend: widgets.legend,
+        layerControl: widgets.layerControl,
+        bookmarks: widgets.bookmarks,
+        find: widgets.find,
+        draw: widgets.draw,
+        measure: widgets.measure,
+        print: widgets.print,
+        directions: widgets.directions,
+        editor: widgets.editor,
+        streetview: widgets.streetview,
+        locale: widgets.locale,
+        help: widgets.help,
+        configSwitch: widgets.configSwitch
+    */
+    config.panes = {
+        left: {
+            open: false
+        }
+    };
+    return config;
+});

--- a/viewer/js/config/viewer.js
+++ b/viewer/js/config/viewer.js
@@ -624,6 +624,27 @@ define([
                 path: 'gis/dijit/Help',
                 title: i18n.viewer.widgets.help,
                 options: {}
+            },
+            configSwitch: {
+                include: true,
+                id: 'configSwitch',
+                //type: 'titlePane',
+                type: 'domNode',
+                srcNodeRef: 'configSwitcher',
+                path: 'gis/dijit/ConfigSwitch',
+                title: 'Switch Config',
+                options: {
+                    configs: [
+                        {
+                            label: 'Default Config',
+                            src: 'viewer'
+                        },
+                        {
+                            label: 'Alternative Config',
+                            src: 'viewer-alternative'
+                        }
+                    ]
+                }
             }
 
         }

--- a/viewer/js/gis/dijit/ConfigSwitch.js
+++ b/viewer/js/gis/dijit/ConfigSwitch.js
@@ -1,0 +1,117 @@
+define([
+    'dojo/_base/declare',
+    'dijit/_WidgetBase',
+    'dijit/_TemplatedMixin',
+
+    'dojo/_base/lang',
+    'dojo/on',
+    'dojo/dom-style',
+    'dojo/_base/array',
+    'dojo/_base/kernel',
+    'dojo/io-query',
+
+    'dijit/form/DropDownButton',
+    'dijit/DropDownMenu',
+    'dijit/MenuItem',
+
+    'viewer/_ConfigMixin',
+
+    'dojo/text!./ConfigSwitch/templates/ConfigSwitch.html',
+
+    'xstyle/css!./ConfigSwitch/css/ConfigSwitch.css'
+], function (
+    declare,
+    _WidgetBase,
+    _TemplatedMixin,
+
+    lang,
+    on,
+    domStyle,
+    array,
+    kernel,
+    ioQuery,
+
+    DropDownButton,
+    DropDownMenu,
+    MenuItem,
+
+    _ConfigMixin,
+
+    template
+) {
+
+    var defaultConfigSrc = _ConfigMixin().defaultConfig;
+    var defaultConfig = {
+        src: defaultConfigSrc,
+        label: 'Default'
+    };
+
+    return declare([_WidgetBase, _TemplatedMixin], {
+        templateString: template,
+        baseClass: 'cmvConfigSwitchDijit',
+
+        currentConfig: defaultConfig,
+
+        configs: [defaultConfig],
+
+        postCreate: function () {
+            this.inherited(arguments);
+
+            if (this.parentWidget) {
+                if (this.parentWidget.toggleable) {
+                    domStyle.set(this.configSwitchLabelContainer, 'display', 'block');
+                }
+            }
+
+            var menu = new DropDownMenu({
+                baseClass: 'configSwitchMenu'
+            });
+
+            var uri = window.location.href, qsObj = {};
+            if (uri.indexOf('?') > -1) {
+                var qs = uri.substring(uri.indexOf('?') + 1, uri.length);
+                qsObj = ioQuery.queryToObject(qs);
+            }
+
+            var currentConfigSrc = qsObj.config || defaultConfigSrc;
+
+            array.forEach(this.configs, lang.hitch(this, function (config) {
+                if (currentConfigSrc === config.src) {
+                    this.currentConfig = config;
+                }
+
+                var menuItem = new MenuItem({
+                    id: config.src,
+                    label: config.label,
+                    onClick: lang.hitch(this, 'switchConfig', config)
+                });
+                menu.addChild(menuItem);
+            }));
+            menu.startup();
+
+            var button = new DropDownButton({
+                label: this.currentConfig.label,
+                dropDown: menu
+            });
+
+            this.configSwitchDropDownContainer.appendChild(button.domNode);
+        },
+
+        switchConfig: function (newConfig) {
+            if (newConfig !== this.currentConfig) {
+                var uri = window.location.href, qsObj = {};
+                if (uri.indexOf('?') > -1) {
+                    var qs = uri.substring(uri.indexOf('?') + 1, uri.length);
+                    qsObj = ioQuery.queryToObject(qs);
+                }
+
+                // set the new locale
+                qsObj.config = newConfig.src;
+
+                // reload the page
+                window.location = window.location.pathname + '?' + ioQuery.objectToQuery(qsObj);
+
+            }
+        }
+    });
+});

--- a/viewer/js/gis/dijit/ConfigSwitch/css/ConfigSwitch.css
+++ b/viewer/js/gis/dijit/ConfigSwitch/css/ConfigSwitch.css
@@ -1,0 +1,7 @@
+.cmvConfigSwitchDijit label {
+    font-weight: bold;
+}
+
+.configSwitchMenuPopup {
+    max-height: 300px;
+}

--- a/viewer/js/gis/dijit/ConfigSwitch/templates/ConfigSwitch.html
+++ b/viewer/js/gis/dijit/ConfigSwitch/templates/ConfigSwitch.html
@@ -1,0 +1,6 @@
+<div class="cmvConfigSwitchDijit">
+    <div data-dojo-attach-point="configSwitchLabelContainer" style="display:none;">
+        <label>Select Config</label>
+    </div>
+    <div data-dojo-attach-point="configSwitchDropDownContainer"></div>
+</div>


### PR DESCRIPTION
<!-- Thank you for contributing to cmv! Contributions are welcome and are
absolutely necessary for the project to stay relevent and useful.
Please fill out the details to ensure others can understand the
changes you are proposing and how they will benefit the project. -->

# Description
<!-- enter a description of the changes here -->
Basic widget to allow switching between multiple configs

# Use case

```javascript
        widgets: {
            // More Widgets...
            configSwitch: {
                include: true,
                id: 'configSwitch',
                //type: 'titlePane',
                type: 'domNode',
                srcNodeRef: 'configSwitcher',
                path: 'gis/dijit/ConfigSwitch',
                title: 'Switch Config',
                options: {
                    configs: [
                        {
                            label: 'Default Config',
                            src: 'viewer'
                        },
                        {
                            label: 'Alternative Config',
                            src: 'viewer-alternative'
                        }
                    ]
                }
            }
            // More Widgets...
        }
```

# Checklist
<!-- please ensure your pull request passes the following check(s) -->

 - [x] `grunt lint` produces no error messages
