### PR TITLE
Enhancement: add the ability to automatically hide identify popup if …

### DIFF
--- a/viewer/js/gis/dijit/Identify.js
+++ b/viewer/js/gis/dijit/Identify.js
@@ -37,6 +37,7 @@ define([
         mapClickMode: null,
         identifies: {},
         infoTemplates: {},
+        hideEmptyPopop: false,
         featureLayers: {},
         ignoreOtherGraphics: true,
         createDefaultInfoTemplates: true,
@@ -368,7 +369,11 @@ define([
                     fSet.push(feature);
                 }, this);
             }, this);
-            this.map.infoWindow.setFeatures(fSet);
+            if (this.hideEmptyPopop && fSet.length === 0) {
+                this.map.infoWindow.hide();
+            } else {
+                this.map.infoWindow.setFeatures(fSet);
+            }
         },
         getFormattedFeature: function (infoTemplate, feature) {
             if (feature.graphic) {


### PR DESCRIPTION
…feature set is empty

<!-- Thank you for contributing to cmv! Contributions are welcome and are
absolutely necessary for the project to stay relevent and useful.
Please fill out the details to ensure others can understand the
changes you are proposing and how they will benefit the project. -->

# Description
Add the ability to hide the popup if no features are identified

# Use case

```javascript
//in identify.js 

return {
        map: true,
        hideEmptyPopop: true,
```

# Checklist
<!-- please ensure your pull request passes the following check(s) -->

 - [ ] `grunt lint` produces no error messages

# Issues addressed: 
https://github.com/cmv/cmv-app/issues/305
https://github.com/cmv/cmv-app/issues/705
