### PR TITLE
Add support for Graphics layer (map and layerControl) and OSM layer (layerControl)

### DIFF
--- a/viewer/js/gis/dijit/LayerControl.js
+++ b/viewer/js/gis/dijit/LayerControl.js
@@ -77,7 +77,9 @@ define([
             imagevector: './LayerControl/controls/ImageVector',
             raster: './LayerControl/controls/Raster',
             stream: './LayerControl/controls/Stream',
-            grouped: './LayerControl/controls/Grouped'
+            grouped: './LayerControl/controls/Grouped',
+            graphics: './LayerControl/controls/Graphics',
+            osm: './LayerControl/controls/OpenStreetMap'
         },
         constructor: function (options) {
             options = options || {};

--- a/viewer/js/gis/dijit/LayerControl/controls/Graphics.js
+++ b/viewer/js/gis/dijit/LayerControl/controls/Graphics.js
@@ -1,0 +1,24 @@
+define([
+    'dojo/_base/declare',
+    'dijit/_WidgetBase',
+    'dijit/_TemplatedMixin',
+    'dijit/_Contained',
+    './_Control' // layer control base class
+], function (
+    declare,
+    _WidgetBase,
+    _TemplatedMixin,
+    _Contained,
+    _Control
+) {
+
+    var GraphicsControl = declare([_WidgetBase, _TemplatedMixin, _Contained, _Control], {
+        _layerType: 'vector', // constant
+        _esriLayerType: 'graphics', // constant
+        _layerTypeInit: function () {
+            this._expandRemove();
+            // legend or no legend???
+        }
+    });
+    return GraphicsControl;
+});

--- a/viewer/js/gis/dijit/LayerControl/controls/OpenStreetMap.js
+++ b/viewer/js/gis/dijit/LayerControl/controls/OpenStreetMap.js
@@ -1,0 +1,23 @@
+define([
+    'dojo/_base/declare',
+    'dijit/_WidgetBase',
+    'dijit/_TemplatedMixin',
+    'dijit/_Contained',
+    './_Control' // layer control base class
+], function (
+    declare,
+    _WidgetBase,
+    _TemplatedMixin,
+    _Contained,
+    _Control
+) {
+
+    var OpenStreetMapControl = declare([_WidgetBase, _TemplatedMixin, _Contained, _Control], {
+        _layerType: 'overlay', // constant
+        _esriLayerType: 'osm', // constant
+        _layerTypeInit: function () {
+            this._expandRemove();
+        }
+    });
+    return OpenStreetMapControl;
+});

--- a/viewer/js/viewer/_MapMixin.js
+++ b/viewer/js/viewer/_MapMixin.js
@@ -109,10 +109,10 @@ define([
                 dynamic: 'esri/layers/ArcGISDynamicMapServiceLayer',
                 feature: 'esri/layers/FeatureLayer',
                 georss: 'esri/layers/GeoRSSLayer',
+                graphics: 'esri/layers/GraphicsLayer',
                 image: 'esri/layers/ArcGISImageServiceLayer',
                 imagevector: 'esri/layers/ArcGISImageServiceVectorLayer',
                 kml: 'esri/layers/KMLLayer',
-                label: 'esri/layers/LabelLayer', //untested
                 mapimage: 'esri/layers/MapImageLayer', //untested
                 osm: 'esri/layers/OpenStreetMapLayer',
                 raster: 'esri/layers/RasterLayer',


### PR DESCRIPTION
Add support for Graphics layer as layer type and layerControl widget
Add OSM layer in layerControl widget
Remove `label` layer type since it has been deprecated by Esri.
