### PR TITLE
Enhancements for grouped layers

### DIFF
--- a/viewer/js/config/viewer.js
+++ b/viewer/js/config/viewer.js
@@ -146,8 +146,7 @@ define([
                 opacity: 1.0,
                 visible: true,
                 outFields: ['*'],
-                mode: 0,
-                groupID: 'Grouped Feature Layers'
+                mode: 0
             },
             editorLayerInfos: {
                 disableGeometryUpdate: false
@@ -157,6 +156,9 @@ define([
                 layerInfo: {
                     title: i18n.viewer.operationalLayers.restaurants
                 }
+            },
+            layerControlLayerInfos: {
+                layerGroup: 'Grouped Feature Layers'
             }
         }, {
             type: 'feature',
@@ -165,12 +167,12 @@ define([
             options: {
                 id: 'sf311Incidents',
                 opacity: 1.0,
-                visible: true,
+                visible: false,
                 outFields: ['req_type', 'req_date', 'req_time', 'address', 'district'],
-                mode: 0,
-                groupID: 'Grouped Feature Layers'
+                mode: 0
             },
             layerControlLayerInfos: {
+                layerGroup: 'Grouped Feature Layers',
                 menu: [{
                     topic: 'hello',
                     label: 'Say Hello Custom',

--- a/viewer/js/gis/dijit/LayerControl.js
+++ b/viewer/js/gis/dijit/LayerControl.js
@@ -33,14 +33,15 @@ define([
         map: null,
         layerInfos: [],
         icons: {
-            expand: 'fa-caret-right',
-            collapse: 'fa-caret-down',
-            checked: 'fa-check-square-o',
-            unchecked: 'fa-square-o',
-            update: 'fa-refresh',
-            menu: 'fa-bars',
-            folder: 'fa-folder-o',
-            folderOpen: 'fa-folder-open-o'
+            expand: 'fa-caret-right fa-fw layerControlIcon-Expand',
+            collapse: 'fa-caret-down fa-fw layerControlIcon-Collapse',
+            checked: 'fa-check fa-fw fa-border layerControlIcon-Checked',
+            unchecked: 'fa-square fa-fw fa-border layerControlIcon-Unchecked',
+            indeterminate: 'fa-minus fa-fw fa-border layerControlIcon-Indeterminate',
+            update: 'fa-refresh layerControlIcon-Update',
+            menu: 'fa-bars layerControlIcon-Menu',
+            folder: 'fa-folder-o fa-fw layerControlIcon-Folder',
+            folderOpen: 'fa-folder-open-o fa-fw layerControlIcon-Folder layerControlIcon-FolderOpen'
         },
         separated: false,
         overlayReorder: false,
@@ -139,10 +140,16 @@ define([
             var modules = [];
             // push layer control mods
             array.forEach(layerInfos, function (layerInfo) {
+                layerInfo.controlOptions = layerInfo.controlOptions || {};
                 // check if control is excluded
                 var controlOptions = layerInfo.controlOptions;
-                if (controlOptions && controlOptions.exclude === true) {
+                if (controlOptions.exclude === true) {
                     return;
+                }
+                // if layerGroups are used, disallow re-ordering
+                if (controlOptions.layerGroup) {
+                    this.overlayReorder = false;
+                    this.vectorReorder = false;
                 }
                 var mod = this._controls[layerInfo.type];
                 if (mod) {
@@ -159,7 +166,7 @@ define([
                 array.forEach(layerInfos, function (layerInfo) {
                     // exclude from widget
                     var controlOptions = layerInfo.controlOptions;
-                    if (controlOptions && controlOptions.exclude === true) {
+                    if (controlOptions.exclude === true) {
                         return;
                     }
                     var control = this._controls[layerInfo.type];
@@ -170,24 +177,27 @@ define([
 
                 for (var key in this._groupedLayerInfos) {
                     if (this._groupedLayerInfos.hasOwnProperty(key)) {
-                        var control = this._controls.grouped;
-                        var hasAnyVisibleLayer = this._groupedLayerInfos[key].some(function (layerDetail) {
-                            return layerDetail.layerInfo.layer.visible;
-                        });
-
-                        var layerInfo = {
-                            title: key,
-                            layer: {
-                                id: key.replace(/\s/g, ''),
-                                loaded: true,
-                                minScale: 0,
-                                maxScale: 0,
-                                _params: {},
-                                visible: hasAnyVisibleLayer // initial visibility depends on grouped layers
-                            },
-                            layerDetails: this._groupedLayerInfos[key]
-                        };
-                        require([control], lang.hitch(this, '_addControl', layerInfo));
+                        var layerDetails = this._groupedLayerInfos[key];
+                        if (layerDetails && layerDetails.length > 1) {
+                            var control = this._controls.grouped;
+                            var layerInfo = {
+                                title: key,
+                                type: 'grouped',
+                                controlOptions: {},
+                                layer: {
+                                    id: key.replace(/\s/g, ''),
+                                    loaded: true,
+                                    getMap: lang.hitch(this, function () {
+                                        return this.map;
+                                    }),
+                                    minScale: 0,
+                                    maxScale: 0,
+                                    _params: {}
+                                },
+                                layerDetails: layerDetails
+                            };
+                            require([control], lang.hitch(this, '_addControl', layerInfo));
+                        }
                     }
                 }
 
@@ -229,7 +239,7 @@ define([
         // create layer control and add to appropriate _container
         _addControl: function (layerInfo, Control) {
             var layer = (typeof layerInfo.layer === 'string') ? this.map.getLayer(layerInfo.layer) : layerInfo.layer;
-            if (layerInfo.controlOptions && (layerInfo.type === 'dynamic' || layerInfo.type === 'feature')) {
+            if (layerInfo.type === 'dynamic' || layerInfo.type === 'feature') {
                 if (layer.loaded) {
                     this._applyLayerControlOptions(layerInfo.controlOptions, layer);
                 } else {
@@ -248,14 +258,21 @@ define([
                     swipe: null,
                     expanded: false,
                     sublayers: true,
+                    layerGroup: null,
                     menu: this.menu[layerInfo.type],
                     subLayerMenu: this.subLayerMenu[layerInfo.type]
                 }, layerInfo.controlOptions)
             });
             layerControl.startup();
             var position = layerInfo.position || 0;
+            var layerType = layerControl._layerType;
+            if (layerType === 'grouped') {
+                if (layerControl.layerDetails && layerControl.layerDetails.length > 0) {
+                    layerControl._layerType = layerControl.layerDetails[0].layerControl._layerType;
+                }
+            }
             if (this.separated) {
-                if (layerControl._layerType === 'overlay') {
+                if (layerType === 'overlay') {
                     this._overlayContainer.addChild(layerControl, position);
                 } else {
                     this._vectorContainer.addChild(layerControl, position);
@@ -266,17 +283,16 @@ define([
             this._storeGroupedLayerInfo(layerInfo, layerControl);
         },
         _storeGroupedLayerInfo: function (layerInfo, layerControl) {
-            var groupID = layerInfo.layer._params.groupID;
-            if (!groupID) {
+            if (!layerInfo.controlOptions.layerGroup) {
                 // Not a grouped layer
                 return;
             }
-
-            if (!this._groupedLayerInfos.hasOwnProperty(groupID)) {
-                this._groupedLayerInfos[groupID] = [];
+            var layerGroup = layerInfo.controlOptions.layerGroup;
+            if (!this._groupedLayerInfos.hasOwnProperty(layerGroup)) {
+                this._groupedLayerInfos[layerGroup] = [];
             }
 
-            this._groupedLayerInfos[groupID].push({
+            this._groupedLayerInfos[layerGroup].push({
                 layerInfo: layerInfo,
                 layerControl: layerControl
             });

--- a/viewer/js/gis/dijit/LayerControl/css/LayerControl.css
+++ b/viewer/js/gis/dijit/LayerControl/css/LayerControl.css
@@ -1,13 +1,8 @@
 .layerControlDijit .vectorLayerContainer {}
 
-.layerControlDijit .vectorLabelContainer {
-    font-size: 15px;
-    font-weight: 600;
-    padding-bottom: 4px;
-}
-
 .layerControlDijit .overlayLayerContainer {}
 
+.layerControlDijit .vectorLabelContainer,
 .layerControlDijit .overlayLabelContainer {
     font-size: 15px;
     font-weight: 600;
@@ -31,43 +26,32 @@
 }
 
 .layerControlDijit .layerControlTable tr {
-    vertical-align: middle;
+    vertical-align: top;
 }
 
 .layerControlDijit .layerControlTable td {
     padding: 0;
 }
 
-.layerControlDijit .layerControlTableExpand {
+.layerControlDijit .layerControlTableExpand,
+.layerControlDijit .layerControlTableCheck,
+.layerControlDijit .layerControlTableMenu,
+.layerControlDijit .layerControlTableLabel {
     cursor: pointer;
-    width: 18px;
-    height: 15px;
-    line-height: 15px;
 }
 
-.layerControlDijit .layerControlTableCheck, .layerControlDijit .layerControlTableMenu {
-    cursor: pointer;
-    width: 19px;
-    height: 16px;
-    line-height: 16px;
+.layerControlDijit .layerControlTableExpand,
+.layerControlDijit .layerControlTableCheck,
+.layerControlDijit .layerControlTableMenu,
+.layerControlDijit .layerControlTableUpdate {
+    text-align: center;
 }
 
 .layerControlDijit .layerControlTableLabel {
-    cursor: pointer;
     font-size: 15px;
-    height: 16px;
     line-height: 16px;
-}
-
-.layerControlDijit .layerControlTableMenu {
-    cursor: pointer;
-}
-
-.layerControlDijit .layerControlTableUpdate {
-    width: 21px;
-    height: 16px;
-    line-height: 16px;
-    text-align: center;
+    padding-top: 2px;
+    width: 100%;
 }
 
 .layerControlDijit .layerControlHidden {
@@ -79,27 +63,79 @@
 }
 
 .layerControlDijit .layerControlIndent {
-    padding-left: 22px;
+    padding-left: 20px;
 }
 
 .layerControlDijit .layerControlIcon {
-    font-size: 17px;
+    font-size: 18px;
+    margin-right: 4px;
+}
+
+.layerControlDijit .layerControlTableExpand .layerControlIcon {
+    margin-right: 0;
+    width: 1em;
+}
+
+.layerControlDijit .layerControlIndent .layerControlTableExpand .layerControlIcon {
+    margin-right: 4px;
+}
+
+.layerControlDijit .layerControlIndent .layerControlIndent .layerControlTableExpand .layerControlIcon,
+.layerControlDijit .layerControlSublayer .layerControlTableExpand .layerControlIcon {
+    margin-left: 4px;
+    margin-right: 4px;
+}
+
+.layerControlDijit .layerControlTableCheck .layerControlIcon {
+    font-size: 12px;
+    height: 13px;
+    width: 13px;
+}
+
+.layerControlDijit .layer-folder {
+    color: #666;
+}
+
+.layerControlDijit .layerControlTableCheck .fa-border {
+    border-color: #333;
+    border-radius: 3px;
+    padding: 0.15em 0.1875em 0.1125em;
+}
+
+
+.layerControlDijit .layerControlTableCheck .layerControlIcon-Folder {
+    color: #333;
+}
+
+.layerControlDijit .layerControlTableCheck .layerControlIcon-Checked {
+    color: #090;
+}
+
+.layerControlDijit .layerControlTableCheck .layerControlIcon-Unchecked:before {
+    color: transparent;
+}
+
+.layerControlDijit .layerControlTableCheck .layerControlIcon-Indeterminate {
+    color: #666;
 }
 
 .layerControlDijit .layerControlUpdateIcon {
+    color: #666;
     font-size: 12px;
 }
 
 .layerControlDijit .layerControlMenuIcon {
     font-size: 15px;
     color: #666;
+    margin-left: 4px;
 }
 
 .layerControlDijit .layerControlMenuIcon:hover {
     color: #111;
 }
 
-.layerControlDijit .layerControlCheckIconOutScale {
+.layerControlDijit .layerControlTableCheck .layerControlCheckIconOutScale {
+    border-color: #BBB;
     color: #BBB;
 }
 
@@ -118,6 +154,10 @@
 
 .layerControlDijit .layerControlClick:hover {
     text-decoration: underline;
+}
+
+.layerControlDijit .layerControlLegendTable {
+    margin: 4px 0;
 }
 
 .layerControlDijit .layerControlLegendTable tr {
@@ -151,7 +191,7 @@
 /* sublayer menu */
 
 .layerControlDijit .layerControlSublayer .layerControlTable td.layerControlTableMenu {
-    padding-right: 20px;
+    padding-right: 16px;
 }
 
 .layerControlDijit .menuClickNode.hidden {


### PR DESCRIPTION
* enable tri-state (indeterminate) checkbox for grouped layers
* new icons for checked/unchecked layers to support addition of tri-state
* don't group layers when there is only 1 layer in group
* don't allow reordering when grouped layers are used
* add a `getMap` function for grouped layers to avoid error with getScale
* change from `groupId` to `layerGroup`
* move layer group to `layerControllayerInfos` to avoid issue with WMS layers
* use `dojo/array`

![image](https://cloud.githubusercontent.com/assets/200780/26342302/62bc342e-3f4c-11e7-85e1-e1dd3428f60a.png)
