### PR TITLE
Add conditional css to hide basemap text on small screens

### DIFF
--- a/viewer/js/gis/dijit/Basemaps.js
+++ b/viewer/js/gis/dijit/Basemaps.js
@@ -44,7 +44,7 @@ define([
         widgetsInTemplate: true,
         i18n: i18n,
         title: i18n.title,
-
+        baseClass: 'basemapWidget',
         basemaps: {},
         currentBasemap: null,
         mapStartBasemap: null,

--- a/viewer/js/gis/dijit/Basemaps/css/Basemaps.css
+++ b/viewer/js/gis/dijit/Basemaps/css/Basemaps.css
@@ -12,3 +12,12 @@
     font-family: FontAwesome;
     content: "\f009";
 }
+
+
+/* condense dropdown on small screens */
+
+@media screen and (max-width: 600px) {
+  #basemaps_widget .dijitButtonText {
+    display: none;
+  }
+}

--- a/viewer/js/gis/dijit/Basemaps/css/Basemaps.css
+++ b/viewer/js/gis/dijit/Basemaps/css/Basemaps.css
@@ -1,14 +1,14 @@
-.selectedIcon:before {
+.basemapWidget .selectedIcon:before {
   font-family: FontAwesome;
   content: "\f046";
 }
 
-.emptyIcon:before {
+.basemapWidget .emptyIcon:before {
   font-family: FontAwesome;
   content: "\f096";
 }
 
-.basemapsIcon:before {
+.basemapWidget .basemapsIcon:before {
   font-family: FontAwesome;
   content: "\f009";
 }

--- a/viewer/js/gis/dijit/Basemaps/css/Basemaps.css
+++ b/viewer/js/gis/dijit/Basemaps/css/Basemaps.css
@@ -1,23 +1,26 @@
 .selectedIcon:before {
-    font-family: FontAwesome;
-    content: "\f046";
+  font-family: FontAwesome;
+  content: "\f046";
 }
 
 .emptyIcon:before {
-    font-family: FontAwesome;
-    content: "\f096";
+  font-family: FontAwesome;
+  content: "\f096";
 }
 
 .basemapsIcon:before {
-    font-family: FontAwesome;
-    content: "\f009";
+  font-family: FontAwesome;
+  content: "\f009";
 }
 
 
 /* condense dropdown on small screens */
 
-@media screen and (max-width: 600px) {
-  #basemaps_widget .dijitButtonText {
+@media (max-width: 768px) {
+  .cmv .map .basemapWidget .dijitDropDownButton .dijitButtonNode {
+    padding: 4px 8px;
+  }
+  .cmv .map .basemapWidget .dijitButtonText {
     display: none;
   }
 }

--- a/viewer/js/gis/dijit/Basemaps/templates/Basemaps.html
+++ b/viewer/js/gis/dijit/Basemaps/templates/Basemaps.html
@@ -1,4 +1,4 @@
-<div>
+<div class="${baseClass}">
     <div data-dojo-type="dijit/form/DropDownButton" data-dojo-props="iconClass:'basemapsIcon'" data-dojo-attach-point="dropDownButton">
         <span>
             ${title}


### PR DESCRIPTION
<!-- Thank you for contributing to cmv! Contributions are welcome and are
absolutely necessary for the project to stay relevent and useful.
Please fill out the details to ensure others can understand the
changes you are proposing and how they will benefit the project. -->

# Description

Mobile friendly basemap dropdown 

![image](https://cloud.githubusercontent.com/assets/5471079/26509642/43502ebc-421f-11e7-8d12-d5c8cd769a25.png)


# Checklist
<!-- please ensure your pull request passes the following check(s) -->

 - [x] `grunt lint` produces no error messages
