### PR TITLE
Trigger streetview 'layoutChange' 

### DIFF
--- a/viewer/js/gis/dijit/StreetView.js
+++ b/viewer/js/gis/dijit/StreetView.js
@@ -73,13 +73,13 @@ define([
                         this.own(aspect.after(this.parentWidget, 'toggle', lang.hitch(this, function () {
                             this.onLayoutChange(this.parentWidget.open);
                         })));
+
+                        // trigger layout change since parentWidget might
+                        // already be open
+                        this.onLayoutChange(this.parentWidget.open);
                     }
                     this.own(aspect.after(this.parentWidget, 'resize', lang.hitch(this, 'resize')));
                     this.own(topic.subscribe(this.parentWidget.id + '/resize/resize', lang.hitch(this, 'resize')));
-
-                    // trigger layout change since parentWidget might
-                    // already be open
-                    this.onLayoutChange(this.parentWidget.open);
                 }
 
                 if (!window.proj4) {

--- a/viewer/js/gis/dijit/StreetView.js
+++ b/viewer/js/gis/dijit/StreetView.js
@@ -76,6 +76,10 @@ define([
                     }
                     this.own(aspect.after(this.parentWidget, 'resize', lang.hitch(this, 'resize')));
                     this.own(topic.subscribe(this.parentWidget.id + '/resize/resize', lang.hitch(this, 'resize')));
+
+                    // trigger layout change since parentWidget might
+                    // already be open
+                    this.onLayoutChange(this.parentWidget.open);
                 }
 
                 if (!window.proj4) {


### PR DESCRIPTION
since parent widget may already be open due to delayed startup

<!-- Thank you for contributing to cmv! Contributions are welcome and are
absolutely necessary for the project to stay relevent and useful.
Please fill out the details to ensure others can understand the
changes you are proposing and how they will benefit the project. -->

# Description

Calls the widget's layout change when the widget is started. onOpen isn't called initially otherwise because the startup is delayed. 


# Checklist

 - [x] `grunt lint` produces no error messages
