### PR TITLE
Remove `lang.clone` config from widget loader

### DIFF
--- a/viewer/js/viewer/_WidgetsMixin.js
+++ b/viewer/js/viewer/_WidgetsMixin.js
@@ -77,7 +77,7 @@ define([
             widgetTypes = widgetTypes || this.widgetTypes;
             for (var key in this.config.widgets) {
                 if (this.config.widgets.hasOwnProperty(key)) {
-                    var widget = lang.clone(this.config.widgets[key]);
+                    var widget = this.config.widgets[key];
                     widget.widgetKey = widget.widgetKey || widget.id || key;
                     if (widget.include && (!this.widgets[widget.widgetKey]) && (array.indexOf(widgetTypes, widget.type) >= 0)) {
                         widget.position = (typeof(widget.position) !== 'undefined') ? widget.position : 10000;


### PR DESCRIPTION
<!-- Thank you for contributing to cmv! Contributions are welcome and are
absolutely necessary for the project to stay relevent and useful.
Please fill out the details to ensure others can understand the
changes you are proposing and how they will benefit the project. -->

# Description

Widget config objects require dojo classes sometimes, like `FeatureLayer` and `BasemapLayer`. `lang.clone` tries to pass the object to the constructor if it encounters these classes, which produces several issues. 

These config objects will only load if you specify a string as `options` though, I think it would be more flexible if we could pass objects with these classes in the config files directly, like `viewer.js`. 

# Checklist
<!-- please ensure your pull request passes the following check(s) -->

 - [x] `grunt lint` produces no error messages
