### PR TITLE
update eslint to latest version (4.1.1).

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,10 @@
 /* https://github.com/eslint/eslint/tree/master/docs/rules */
 {
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "sourceType": "module"
+    },
+
     "rules": {
 
         /*
@@ -7,37 +12,36 @@
             The follow rules point out areas where you
             might have made mistakes.
         */
-        "comma-dangle": [2, "never"],
-        "no-cond-assign": 2,
-        "no-console": 2,
-        "no-constant-condition": 2,
-        "no-control-regex": 2,
-        "no-debugger": 1,
-        "no-dupe-args": 2,
-        "no-dupe-keys": 2,
-        "no-duplicate-case": 2,
-        "no-empty-character-class": 2,
-        "no-empty": 2,
-        "no-ex-assign": 2,
-        "no-extra-boolean-cast": 2,
-        "no-extra-semi": 2,
-        "no-func-assign": 2,
-        "no-inner-declarations": 2,
-        "no-invalid-regexp": 2,
-        "no-irregular-whitespace": 2,
-        "no-negated-in-lhs": 2,
-        "no-obj-calls": 2,
-        "no-regex-spaces": 2,
-        "no-sparse-arrays": 2,
-        "no-unexpected-multiline": 2,
-        "no-unreachable": 2,
-        "use-isnan": 2,
-        "valid-jsdoc": 2,
-        "valid-typeof": 2,
+        "comma-dangle": ["error", "never"],
+        "no-cond-assign": "error",
+        "no-console": "error",
+        "no-constant-condition": "error",
+        "no-control-regex": "error",
+        "no-debugger": "error",
+        "no-dupe-args": "error",
+        "no-dupe-keys": "error",
+        "no-duplicate-case": "error",
+        "no-empty-character-class": "error",
+        "no-empty": "error",
+        "no-ex-assign": "error",
+        "no-extra-boolean-cast": "error",
+        "no-extra-semi": "error",
+        "no-func-assign": "error",
+        "no-inner-declarations": "error",
+        "no-invalid-regexp": "error",
+        "no-irregular-whitespace": "error",
+        "no-negated-in-lhs": "error",
+        "no-obj-calls": "error",
+        "no-regex-spaces": "error",
+        "no-sparse-arrays": "error",
+        "no-unexpected-multiline": "error",
+        "no-unreachable": "error",
+        "use-isnan": "error",
+        "valid-jsdoc": "error",
+        "valid-typeof": "error",
 
         // ignored possible errors
-        "no-extra-parens": 0,
-
+        "no-extra-parens": "off",
 
         /*
             Best Practices
@@ -45,202 +49,208 @@
             mistakes. They either prescribe a better way of
             doing something or help you avoid footguns.
         */
-        "accessor-pairs": [2, {
+        "accessor-pairs": ["error", {
             "getWithoutSet": true
         }],
-        "block-scoped-var": 2,
-        "complexity": [2, 20], /** TODO should try to get this lower **/
-        "consistent-return": 2,
-        "curly": 2,
-        "default-case": 2,
-        "dot-location": [2, "property"],
-        "dot-notation": 2,
-        "eqeqeq": 2,
-        "guard-for-in": 2,
-        "max-statements": [1, 30, {"ignoreTopLevelFunctions": true}],
-        "no-alert": 2,
-        "no-caller": 2,
-        "no-div-regex": 2,
-        "no-empty-pattern": 2,
-        "no-eq-null": 2,
-        "no-eval": 2,
-        "no-extend-native": 2,
-        "no-extra-bind": 2,
-        "no-fallthrough": 2,
-        "no-floating-decimal": 2,
-        "no-implicit-coercion": 2,
-        "no-implied-eval": 2,
-        "no-iterator": 2,
-        "no-labels": 2,
-        "no-lone-blocks": 2,
-        "no-loop-func": 2,
-        "no-multi-spaces": 2,
-        "no-multi-str": 2,
-        "no-native-reassign": 2,
-        "no-new-func": 2,
-        "no-new-wrappers": 2,
-        "no-new": 2,
-        "no-octal-escape": 2,
-        "no-octal": 2,
-        "no-process-env": 2,
-        "no-proto": 2,
-        "no-redeclare": 2,
-        "no-return-assign": 2,
-        "no-script-url": 2,
-        "no-self-compare": 2,
-        "no-sequences": 2,
-        "no-throw-literal": 2,
-        "no-unused-expressions": 2,
-        "no-useless-call": 2,
-        "no-useless-concat": 2,
-        "no-void": 2,
-        "no-with": 2,
-        "radix": 2,
-        "wrap-iife": [2, "inside"],
-        "yoda": 2,
+        "block-scoped-var": "error",
+        "complexity": "error",
+        "consistent-return": "error",
+        "curly": "error",
+        "default-case": "error",
+        "dot-location": ["error", "property"],
+        "dot-notation": "error",
+        "eqeqeq": "error",
+        "guard-for-in": "error",
+        "no-alert": "error",
+        "no-caller": "error",
+        "no-compare-neg-zero": "error",
+        "no-div-regex": "error",
+        "no-empty-pattern": "error",
+        "no-eq-null": "error",
+        "no-eval": "error",
+        "no-extend-native": "error",
+        "no-extra-bind": "error",
+        "no-fallthrough": "error",
+        "no-floating-decimal": "error",
+        "no-implicit-coercion": "error",
+        "no-implied-eval": "error",
+        "no-iterator": "error",
+        "no-labels": "error",
+        "no-lone-blocks": "error",
+        "no-loop-func": "error",
+        "no-multi-spaces": "error",
+        "no-multi-str": "error",
+        "no-native-reassign": "error",
+        "no-new-func": "error",
+        "no-new-wrappers": "error",
+        "no-new": "error",
+        "no-octal-escape": "error",
+        "no-octal": "error",
+        "no-process-env": "error",
+        "no-proto": "error",
+        "no-redeclare": "error",
+        "no-return-assign": "error",
+        "no-script-url": "error",
+        "no-self-compare": "error",
+        "no-sequences": "error",
+        "no-throw-literal": "error",
+        "no-unused-expressions": "error",
+        "no-useless-call": "error",
+        "no-useless-concat": "error",
+        "no-void": "error",
+        "no-with": "error",
+        "radix": "error",
+        "wrap-iife": ["error", "inside"],
+        "yoda": "error",
+
+        // best practices rules to keep an eye on and consider fixing
+        "max-statements": ["warn", 15],
+        "no-else-return": "warn",
+        "no-useless-escape": "warn",
 
         // ignored best practices rules
-        "no-else-return": 0,
-        "no-invalid-this": 0,
-        "no-magic-numbers": 0,
-        "no-param-reassign": 0,
-        "no-warning-comments": 0,
-        "vars-on-top": 0,
+        "no-invalid-this": "off",
+        "no-magic-numbers": "off",
+        "no-param-reassign": "off",
+        "no-warning-comments": "off",
+        "vars-on-top": "off",
 
 
         /*
             Strict Mode
         */
-            "strict": 2,
+            "strict": "error",
 
 
         /*
             Variables
             These rules have to do with variable declarations.
         */
-        "no-catch-shadow": 2,
-        "no-delete-var": 2,
-        "no-label-var": 2,
-        "no-shadow-restricted-names": 2,
-        "no-shadow": 2,
-        "no-undef-init": 2,
-        "no-undef": 2,
-        "no-unused-vars": 2,
-        "no-use-before-define": 2,
+        "no-catch-shadow": "error",
+        "no-delete-var": "error",
+        "no-label-var": "error",
+        "no-shadow-restricted-names": "error",
+        "no-shadow": "error",
+        "no-undef-init": "error",
+        "no-unused-vars": "error",
+        "no-use-before-define": "error",
 
-        // ignore variable rules
-        "init-declarations": 0,
-        "no-undefined": 0,
-
+        // variable rules to keep an eye on and consider fixing
+        "init-declarations": "warn",
+        "no-undef": "warn",
+        "no-undefined": "warn",
 
         /*
             Stylistic Issues
             These rules are purely matters of style and
             are quite subjective.
         */
-        "array-bracket-spacing": [2, "never"],
-        "block-spacing": [2, "always"],
-        "brace-style": [2, "1tbs", {
+        "array-bracket-spacing": ["error", "never"],
+        "block-spacing": ["error", "always"],
+        "brace-style": ["error", "1tbs", {
             "allowSingleLine": false
         }],
-        "camelcase": 2,
-        "comma-spacing": [2, {
+        "camelcase": "error",
+        "comma-spacing": ["error", {
             "before": false,
             "after": true
         }],
-        "comma-style": 2,
-        "computed-property-spacing": [2, "never"],
-        "consistent-this": [2, "self"],
-        "func-style": [2, "declaration"],
-        "indent": [2, 4],
-        "key-spacing": [2, {
+        "comma-style": "error",
+        "computed-property-spacing": ["error", "never"],
+        "consistent-this": ["error", "self"],
+        "func-style": ["error", "declaration"],
+        "indent": ["error", 4],
+        "key-spacing": ["error", {
             "beforeColon": false,
             "afterColon": true,
             "mode": "strict"
         }],
-        "keyword-spacing": [2, {"before": true, "after": true, "overrides": {}}],
-        "max-nested-callbacks": [2, 4],
-        "new-cap": 2,
-        "new-parens": 2,
-        "no-array-constructor": 2,
-        "no-continue": 2,
-        "no-lonely-if": 2,
-        "no-mixed-spaces-and-tabs": 2,
-        "no-multiple-empty-lines": 2,
-        "object-curly-spacing": [2, "never"],
-        "operator-assignment": 2,
-        "operator-linebreak": 2,
-        "quotes": [2, "single"],
-        "semi-spacing": [2, {
+        "keyword-spacing": ["error", {
+            "before": true,
+            "after": true,
+            "overrides": {}
+        }],
+        "id-match": "error",
+        "max-nested-callbacks": ["error", 4],
+        "new-cap": "error",
+        "new-parens": "error",
+        "no-array-constructor": "error",
+        "no-continue": "error",
+        "no-lonely-if": "error",
+        "no-mixed-spaces-and-tabs": "error",
+        "no-multiple-empty-lines": "error",
+        "object-curly-spacing": ["error", "never"],
+        "operator-assignment": "error",
+        "operator-linebreak": "error",
+        "quotes": ["error", "single"],
+        "semi-spacing": ["error", {
             "before": false,
             "after": true
         }],
-        "semi": [2, "always"],
-        "space-before-blocks": [2, "always"],
-        "space-before-function-paren": [2, "always"],
-        "space-in-parens": [2, "never"],
-        "space-infix-ops": 2,
-        "wrap-regex": 2,
+        "semi": ["error", "always"],
+        "space-before-blocks": ["error", "always"],
+        "space-before-function-paren": ["error", "always"],
+        "space-in-parens": ["error", "never"],
+        "space-infix-ops": "error",
+        "wrap-regex": "error",
+
+        // stylistic rules to keep an eye on and consider fixing
+        "space-unary-ops": "warn",
 
         // ignored stylistic rules
-        "eol-last": 0,
-        "func-names": 0,
-        "id-match": 0,
-        "jsx-quotes": 0,
-        "lines-around-comment": 0,
-        "linebreak-style": 0,
-        "newline-after-var": 0,
-        "no-inline-comments": 0,
-        "no-negated-condition": 0,
-        "no-underscore-dangle": 0,
-        "one-var": 0,
-        "padded-blocks": 0,
-        "quote-props": 0,
-        "require-jsdoc": 0,
-        "space-unary-ops": 0,
-        "spaced-comment": 0,
+        "eol-last": "off",
+        "func-names": "off",
+        "jsx-quotes": "off",
+        "lines-around-comment": "off",
+        "linebreak-style": "off",
+        "no-inline-comments": "off",
+        "no-negated-condition": "off",
+        "no-underscore-dangle": "off",
+        "one-var": "off",
+        "padded-blocks": "off",
+        "padding-line-between-statements": "off",
+        "quote-props": "off",
+        "require-jsdoc": "off",
+        "spaced-comment": "off",
 
 
         /*
             ECMAScript 6
             These rules are only relevant to ES6 environments.
         */
-        "arrow-parens": [2, "always"],
-        "arrow-spacing": [2, {
+        "arrow-parens": ["error", "always"],
+        "arrow-spacing": ["error", {
             "before": true,
             "after": true
         }],
-        "constructor-super": 2,
-        "generator-star-spacing": [2, {
+        "constructor-super": "error",
+        "generator-star-spacing": ["error", {
             "before": true,
             "after": true
         }],
-        "no-class-assign": 2,
-        "no-const-assign": 2,
-        "no-dupe-class-members": 2,
-        "no-this-before-super": 2,
-        "prefer-const": 2,
-        "prefer-spread": 2,
-        "require-yield": 2,
+        "no-class-assign": "error",
+        "no-const-assign": "error",
+        "no-dupe-class-members": "error",
+        "no-this-before-super": "error",
+        "prefer-const": "error",
+        "prefer-spread": "error",
+        "require-yield": "error",
 
         // ignored ECMA6  rules
-        "no-arrow-condition": 0,
-        "no-var": 0,
-        "object-shorthand": 0,
-        "prefer-arrow-callback": 0,
-        "prefer-reflect": 0,
+        "no-arrow-condition": "off",
+        "no-var": "off",
+        "object-shorthand": "off",
+        "prefer-arrow-callback": "off",
+        "prefer-reflect": "off",
         "prefer-template": 0
 
     },
     "env": {
         "amd": true,
-        "es6": true,
         "browser": true
     },
     "globals": {
         "define": true,
         "require": true
-    },
-    "parser": "babel-eslint",
-    "extends": "eslint:recommended"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -7,9 +7,8 @@
     "homepage": "https://cmv.io/",
     "repository": "https://github.com/cmv/cmv-app/",
     "dependencies": {
-        "babel-eslint": "~7.2.0",
         "csslint": "1.0.x",
-        "eslint": "~3.19.0",
+        "eslint": "~4.1.1",
         "grunt": "1.0.x",
         "grunt-contrib-clean": "~1.1.0",
         "grunt-contrib-compress": "~1.4.1",


### PR DESCRIPTION
remove babel-eslint parser currently incompatible with eslint 4, replace with parserOptions.
change some previously ignored eslint rules to warnings for us to consider fixing.
restructure eslintrc file.