### PR TITLE
don't adjust extent for view padding when the passed extent has a spatial reference different from the map.

### DIFF
--- a/viewer/js/viewer/sidebar/Sidebar.js
+++ b/viewer/js/viewer/sidebar/Sidebar.js
@@ -129,6 +129,9 @@ define([
         },
 
         _viewPaddingHandler: function (extent) {
+            if (extent.spatialReference !== this.map.extent.spatialReference) {
+                return [extent];
+            }
             var map = this.map,
                 vp = this.viewPadding,
                 w = map.width - vp.left - vp.right,


### PR DESCRIPTION
fixes #753