### PR TITLE
Add option to use alternative visibility mode instead of triStateTree for dynamic layer group folders

### DIFF
--- a/viewer/js/gis/dijit/LayerControl.js
+++ b/viewer/js/gis/dijit/LayerControl.js
@@ -94,7 +94,7 @@ define([
             }
             // add any user-defined controls - possibly for user-defined layers
             this._controls = lang.mixin(this._controls, options.controls || {});
-            if(options.triStateTree){
+            if (options.triStateTree) {
                 triStateTree = true;
             }
         },

--- a/viewer/js/gis/dijit/LayerControl.js
+++ b/viewer/js/gis/dijit/LayerControl.js
@@ -48,6 +48,7 @@ define([
         overlayLabel: false,
         vectorReorder: false,
         vectorLabel: false,
+        triStateTree: false,
         noMenu: null,
         noLegend: null,
         noZoom: null,
@@ -93,6 +94,9 @@ define([
             }
             // add any user-defined controls - possibly for user-defined layers
             this._controls = lang.mixin(this._controls, options.controls || {});
+            if(options.triStateTree){
+                triStateTree = true;
+            }
         },
         postCreate: function () {
             this.inherited(arguments);
@@ -261,6 +265,7 @@ define([
                     noLegend: null,
                     noZoom: null,
                     noTransparency: null,
+                    triStateTree: this.triStateTree,
                     swipe: null,
                     expanded: false,
                     sublayers: true,

--- a/viewer/js/gis/dijit/LayerControl/controls/Dynamic.js
+++ b/viewer/js/gis/dijit/LayerControl/controls/Dynamic.js
@@ -56,7 +56,7 @@ define([
                 // we have sublayer controls
                 this._hasSublayers = true;
                 this._visLayersHandler = aspect.after(this.layer, 'setVisibleLayers', lang.hitch(this, '_onSetVisibleLayers'), true);
-                this.layer.setAllVisibleLayers = lang.hitch(this, function(allVisibleLayers) {
+                this.layer.setAllVisibleLayers = lang.hitch(this, function (allVisibleLayers) {
                     this.layer.allVisibleLayers = allVisibleLayers;
                     this._onSetVisibleLayers(allVisibleLayers, true);
                     this._setVisibleLayers(allVisibleLayers);
@@ -117,7 +117,7 @@ define([
                     return l.id;
                 });
                 array.forEach(layer.layerInfos, lang.hitch(this, '_createControl', layer, allLayers));
-                if(this.controlOptions.triStateTree){
+                if (this.controlOptions.triStateTree) {
                     array.forEach(this._folderControls, function (control) {
                         control._checkFolderVisibility();
                     });
@@ -238,20 +238,21 @@ define([
                 array.forEach(subLayers, lang.hitch(this, function (subLayer) {
                     if (subLayer._isVisible()) {
                         allVisibleLayers.push(subLayer.sublayerInfo.id);
-                        if(this.controlOptions.triStateTree){
+                        if (this.controlOptions.triStateTree) {
                             visibleLayers.push(subLayer.sublayerInfo.id);
                             return;
                         }
                     }
                     var currentLayer = subLayer;
                     var oldLayer = null;
-                    while(currentLayer._isVisible() && currentLayer.sublayerInfo.parentLayerId !== -1 && oldLayer != currentLayer) {
+                    function checkParent (f) {
+                        if (f.sublayerInfo.id === currentLayer.sublayerInfo.parentLayerId) {
+                            currentLayer = f;
+                        }
+                    }
+                    while (currentLayer._isVisible() && currentLayer.sublayerInfo.parentLayerId !== -1 && oldLayer !== currentLayer) {
                         oldLayer = currentLayer;
-                        array.forEach(this._folderControls, function (f) {
-                            if (f.sublayerInfo.id === currentLayer.sublayerInfo.parentLayerId) {
-                                currentLayer = f;
-                            }
-                        });
+                        array.forEach(this._folderControls, checkParent);
                     }
                     if (currentLayer._isVisible()) {
                         visibleLayers.push(subLayer.sublayerInfo.id);
@@ -263,7 +264,7 @@ define([
                 visibleLayers.push(-1);
             }
             
-            if(this.controlOptions.triStateTree){
+            if (this.controlOptions.triStateTree) {
                 array.forEach(this._folderControls, function (control) {
                     control._checkFolderVisibility();
                 });
@@ -301,7 +302,7 @@ define([
                 control._setFolderCheckbox(viz, null, noPublish);
             });
             
-            if(this.controlOptions.triStateTree){
+            if (this.controlOptions.triStateTree) {
                 // finally, set the folder UI (state of checkbox) based on
                 // the sub layers and folders within the parent folder
                 array.forEach(this._folderControls, function (control) {

--- a/viewer/js/gis/dijit/LayerControl/controls/Dynamic.js
+++ b/viewer/js/gis/dijit/LayerControl/controls/Dynamic.js
@@ -56,6 +56,11 @@ define([
                 // we have sublayer controls
                 this._hasSublayers = true;
                 this._visLayersHandler = aspect.after(this.layer, 'setVisibleLayers', lang.hitch(this, '_onSetVisibleLayers'), true);
+                this.layer.setAllVisibleLayers = lang.hitch(this, function(allVisibleLayers) {
+                    this.layer.allVisibleLayers = allVisibleLayers;
+                    this._onSetVisibleLayers(allVisibleLayers, true);
+                    this._setVisibleLayers(allVisibleLayers);
+                });
             }
         },
         // create sublayers and legend
@@ -112,10 +117,11 @@ define([
                     return l.id;
                 });
                 array.forEach(layer.layerInfos, lang.hitch(this, '_createControl', layer, allLayers));
-
-                array.forEach(this._folderControls, function (control) {
-                    control._checkFolderVisibility();
-                });
+                if(this.controlOptions.triStateTree){
+                    array.forEach(this._folderControls, function (control) {
+                        control._checkFolderVisibility();
+                    });
+                }
             }
         },
 
@@ -209,33 +215,59 @@ define([
             // remove aspect handler
             this._visLayersHandler.remove();
             var layer = this.layer,
-                visibleLayers = [];
+                visibleLayers = [],
+                allVisibleLayers = [];
 
             // get visibility of sub layers not in folders
             array.forEach(this._sublayerControls, function (subLayer) {
                 if (subLayer._isVisible() && subLayer.parentLayerId === -1) {
                     visibleLayers.push(subLayer.sublayerInfo.id);
+                    allVisibleLayers.push(subLayer.sublayerInfo.id);
                 }
             });
 
+            array.forEach(this._folderControls, lang.hitch(this, function (folder) {
+                if (folder._isVisible() || (this.controlOptions.triStateTree && folder._hasAnyVisibleLayer())) {
+                    allVisibleLayers.push(folder.sublayerInfo.id);
+                }
+            }));
+
             // get visibility of sub layers that are contained within a folder
-            array.forEach(this._folderControls, function (folder) {
+            array.forEach(this._folderControls, lang.hitch(this, function (folder) {
                 var subLayers = folder._getSubLayerControls();
-                array.forEach(subLayers, function (subLayer) {
+                array.forEach(subLayers, lang.hitch(this, function (subLayer) {
                     if (subLayer._isVisible()) {
+                        allVisibleLayers.push(subLayer.sublayerInfo.id);
+                        if(this.controlOptions.triStateTree){
+                            visibleLayers.push(subLayer.sublayerInfo.id);
+                            return;
+                        }
+                    }
+                    var currentLayer = subLayer;
+                    var oldLayer = null;
+                    while(currentLayer._isVisible() && currentLayer.sublayerInfo.parentLayerId !== -1 && oldLayer != currentLayer) {
+                        oldLayer = currentLayer;
+                        array.forEach(this._folderControls, function (f) {
+                            if (f.sublayerInfo.id === currentLayer.sublayerInfo.parentLayerId) {
+                                currentLayer = f;
+                            }
+                        });
+                    }
+                    if (currentLayer._isVisible()) {
                         visibleLayers.push(subLayer.sublayerInfo.id);
                     }
-
-                });
-            });
+                }));
+            }));
 
             if (!visibleLayers.length) {
                 visibleLayers.push(-1);
             }
-
-            array.forEach(this._folderControls, function (control) {
-                control._checkFolderVisibility();
-            });
+            
+            if(this.controlOptions.triStateTree){
+                array.forEach(this._folderControls, function (control) {
+                    control._checkFolderVisibility();
+                });
+            }
 
             layer.setVisibleLayers(visibleLayers);
             layer.refresh();
@@ -244,28 +276,38 @@ define([
                 id: layer.id,
                 visibleLayers: visibleLayers
             });
+            
+            topic.publish('layerControl/setAllVisibleLayers', {
+                id: layer.id,
+                allVisibleLayers: allVisibleLayers
+            });
+
+            this.layer.allVisibleLayers = allVisibleLayers;
+
             // set aspect handler
             this._visLayersHandler = aspect.after(this.layer, 'setVisibleLayers', lang.hitch(this, '_onSetVisibleLayers'), true);
         },
-        _onSetVisibleLayers: function (visLayers) {
+        _onSetVisibleLayers: function (visLayers, noPublish) {
             // set the sub layer visibility first
             array.forEach(this._sublayerControls, function (control) {
                 var viz = (array.indexOf(visLayers, control.sublayerInfo.id) !== -1);
-                control._setSublayerCheckbox(viz);
+                control._setSublayerCheckbox(viz, null, noPublish);
             });
 
             // setting the folder (group layer) visibility will change
             // visibility for all children sub layer and folders
             array.forEach(this._folderControls, function (control) {
                 var viz = (array.indexOf(visLayers, control.sublayerInfo.id) !== -1);
-                control._setFolderCheckbox(viz);
+                control._setFolderCheckbox(viz, null, noPublish);
             });
-
-            // finally, set the folder UI (state of checkbox) based on
-            // the sub layers and folders within the parent folder
-            array.forEach(this._folderControls, function (control) {
-                control._checkFolderVisibility();
-            });
+            
+            if(this.controlOptions.triStateTree){
+                // finally, set the folder UI (state of checkbox) based on
+                // the sub layers and folders within the parent folder
+                array.forEach(this._folderControls, function (control) {
+                    control._checkFolderVisibility();
+                });
+            }
         }
     });
     return DynamicControl;

--- a/viewer/js/gis/dijit/LayerControl/controls/_DynamicFolder.js
+++ b/viewer/js/gis/dijit/LayerControl/controls/_DynamicFolder.js
@@ -52,7 +52,7 @@ define([
                     event.stopPropagation();
                 }
 
-                if(this.control.controlOptions.triStateTree){
+                if (this.control.controlOptions.triStateTree) {
                     if (!this._hasAnyInvisibleLayer()) {
                         this._setFolderCheckbox(false, checkNode);
                     } else {
@@ -99,7 +99,7 @@ define([
             var i = this.icons;
             checkNode = checkNode || this.checkNode;
             
-            if(this.control.controlOptions.triStateTree) {
+            if (this.control.controlOptions.triStateTree) {
                 var slNodes = this._getSubLayerNodes(),
                     dataChecked = (checked) ? 'checked' : 'unchecked';
                 array.forEach(slNodes, lang.hitch(this, function (node) {
@@ -132,7 +132,7 @@ define([
                 }
             }
 
-            if(!noPublish){
+            if (!noPublish) {
                 this.control._setVisibleLayers();
             }
         },

--- a/viewer/js/gis/dijit/LayerControl/controls/_DynamicFolder.js
+++ b/viewer/js/gis/dijit/LayerControl/controls/_DynamicFolder.js
@@ -31,6 +31,7 @@ define([
         control: null,
         sublayerInfo: null,
         icons: null,
+        triStateTree: false,
         // ^args
         templateString: folderTemplate,
         _expandClickHandler: null,
@@ -51,11 +52,16 @@ define([
                     event.stopPropagation();
                 }
 
-                if (!this._hasAnyInvisibleLayer()) {
-                    this._setFolderCheckbox(false, checkNode);
+                if(this.control.controlOptions.triStateTree){
+                    if (!this._hasAnyInvisibleLayer()) {
+                        this._setFolderCheckbox(false, checkNode);
+                    } else {
+                        this._setFolderCheckbox(true, checkNode);
+                    }
                 } else {
-                    this._setFolderCheckbox(true, checkNode);
+                    this._setFolderCheckbox(!this._isVisible(), checkNode);
                 }
+                
                 this._checkboxScaleRange();
             })));
             html.set(this.labelNode, this.sublayerInfo.name);
@@ -89,33 +95,44 @@ define([
         },
 
         // toggles visibility of all sub layers
-        _setFolderCheckbox: function (checked, checkNode, isChildFolder) {
-            var i = this.icons,
-                dataChecked = (checked) ? 'checked' : 'unchecked',
-                slNodes = this._getSubLayerNodes();
+        _setFolderCheckbox: function (checked, checkNode, noPublish) {
+            var i = this.icons;
             checkNode = checkNode || this.checkNode;
-            array.forEach(slNodes, lang.hitch(this, function (node) {
-
-                // child is folder
-                if (domAttr.get(node, 'data-layer-folder')) {
-                    var folderControl = this._getFolderControl(node);
-                    if (folderControl) {
-                        folderControl._setFolderCheckbox(checked, node, true);
-                    }
-                // child is sub layer
-                } else {
-                    domAttr.set(node, 'data-checked', dataChecked);
-                    if (checked) {
-                        domClass.replace(node, i.checked, i.unchecked);
+            
+            if(this.control.controlOptions.triStateTree) {
+                var slNodes = this._getSubLayerNodes(),
+                    dataChecked = (checked) ? 'checked' : 'unchecked';
+                array.forEach(slNodes, lang.hitch(this, function (node) {
+                    // child is folder
+                    if (domAttr.get(node, 'data-layer-folder')) {
+                        var folderControl = this._getFolderControl(node);
+                        if (folderControl) {
+                            folderControl._setFolderCheckbox(checked, node, true);
+                        }
+                    // child is sub layer
                     } else {
-                        domClass.replace(node, i.unchecked, i.checked);
+                        domAttr.set(node, 'data-checked', dataChecked);
+                        if (checked) {
+                            domClass.replace(node, i.checked, i.unchecked);
+                        } else {
+                            domClass.replace(node, i.unchecked, i.checked);
+                        }
                     }
-                }
-            }));
+                }));
+            } else {
+                domClass.remove(checkNode, i.checked);
+                domClass.remove(checkNode, i.unchecked);
 
-            // wait until all folders in hierarchy have been
-            // processed before setting the layer's visible layers
-            if (!isChildFolder) {
+                if (checked) {
+                    domAttr.set(checkNode, 'data-checked', 'checked');
+                    domClass.add(checkNode, i.checked);
+                } else {
+                    domAttr.set(checkNode, 'data-checked', 'unchecked');
+                    domClass.add(checkNode, i.unchecked);
+                }
+            }
+
+            if(!noPublish){
                 this.control._setVisibleLayers();
             }
         },
@@ -198,7 +215,7 @@ define([
             }
             return null;
         },
-
+        
         // set visibility of folder (group layer) based on the visibility
         // of children sub-layers and folders
         _checkFolderVisibility: function () {


### PR DESCRIPTION
<!-- Thank you for contributing to cmv! Contributions are welcome and are
absolutely necessary for the project to stay relevent and useful.
Please fill out the details to ensure others can understand the
changes you are proposing and how they will benefit the project. -->

# Description
<!-- enter a description of the changes here -->
Expands on pull request #747, as suggested by @tmcgee in [this](https://github.com/cmv/cmv-app/pull/747#issuecomment-326049869) comment.


# Checklist
<!-- please ensure your pull request passes the following check(s) -->

 - [x] `grunt lint` produces no error messages
