### PR TITLE
Fix incorrect class prefix for icons in basemap widget's dropdown menu

### DIFF
--- a/viewer/js/gis/dijit/Basemaps.js
+++ b/viewer/js/gis/dijit/Basemaps.js
@@ -127,6 +127,7 @@ define([
 
         buildMenu: function () {
             this.menu = new DropDownMenu({
+                class: this.baseClass + '-menu',
                 style: 'display: none;'
             });
             array.forEach(this.basemapsToShow, function (basemap) {

--- a/viewer/js/gis/dijit/Basemaps/css/Basemaps.css
+++ b/viewer/js/gis/dijit/Basemaps/css/Basemaps.css
@@ -1,14 +1,14 @@
-.basemapWidget .selectedIcon:before,
-.basemapWidget .emptyIcon:before,
+.basemapWidget-menu .selectedIcon:before,
+.basemapWidget-menu .emptyIcon:before,
 .basemapWidget .basemapsIcon:before {
   font-family: FontAwesome;
 }
 
-.basemapWidget .selectedIcon:before {
+.basemapWidget-menu .selectedIcon:before {
   content: "\f046";
 }
 
-.basemapWidget .emptyIcon:before {
+.basemapWidget-menu .emptyIcon:before {
   content: "\f096";
 }
 


### PR DESCRIPTION
Icons are missing in the basemap widget's menu due to incorrect class prefixes in style:

## Before:
![image](https://user-images.githubusercontent.com/200780/30938817-3e25061a-a390-11e7-8c1c-a6eaf8bf5c30.png)

## After:
![image](https://user-images.githubusercontent.com/200780/30938948-b8c00eec-a390-11e7-802f-a1351acfa5f6.png)
