### PR TITLE
Add new identify topics

### DIFF
--- a/viewer/js/gis/dijit/Identify.js
+++ b/viewer/js/gis/dijit/Identify.js
@@ -188,7 +188,7 @@ define([
         },
         removeLayerInfo: function (layerInfo) {
             var lyrId = layerInfo.id;
-            var layers = [], listener = null;
+            var layers = [], listeners = null;
             array.forEach(this.layers, function (layer) {
                 if (layer.ref.id !== lyrId) {
                     layers.push(layer);


### PR DESCRIPTION
Added the following published topics:

1. `identify/execute`
2. `identify/results`
3. `identify/error`

These are intended to allow more control for widgets like IdentifyPanel.

Added the following subscribed topic:

1. `identify/removeLayerInfos`

This allows for removing the layer when it is removed from the map such as the DragAndDrop widget. This addition required changes when adding LayerInfos to capture the error handler for later removal.

Added a `showPopup` property so visibility of the map's infoWindow can be managed outside of the Identify widget (such as from the IdentifyPanel widget).