### PR TITLE
Bookmarks Widget not loading in Javascript Api 3.22

### DIFF
--- a/viewer/js/gis/dijit/Bookmarks.js
+++ b/viewer/js/gis/dijit/Bookmarks.js
@@ -1,42 +1,45 @@
 define([
-    'dojo/_base/declare',
-    'dijit/_WidgetBase',
-    'esri/dijit/Bookmarks',
-    'dojo/json',
-    'dojo/cookie',
+	'dojo/_base/declare',
+	'dijit/_WidgetBase',
+    'dijit/_TemplatedMixin',
+    'dijit/_WidgetsInTemplateMixin',
+   	'esri/dijit/Bookmarks',
+    'dojo/text!./Bookmarks/templates/Bookmarks.html',
+	'dojo/json',
+	'dojo/cookie',
     'dojo/_base/lang',
-    'xstyle/css!./Bookmarks/css/Bookmarks.css'
-], function (declare, _WidgetBase, Bookmarks, json, cookie, lang) {
+	'xstyle/css!./Bookmarks/css/Bookmarks.css'
+], function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, Bookmarks, template, json, cookie, lang) {
 
-    return declare([_WidgetBase], {
-        declaredClass: 'gis.digit.Bookmarks',
-        postCreate: function () {
-            this.inherited(arguments);
-            var bookmarks = this.bookmarks; // from the options passed in
-            this.bookmarkItems = cookie('bookmarkItems');
-            if (this.bookmarkItems === undefined) {
-                this.bookmarkItems = [];
-            } else {
-                this.bookmarkItems = json.parse(this.bookmarkItems);
-            }
-
+    return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
+        templateString: template,
+		postCreate: function () {
+			this.inherited(arguments);
+			var bookmarks = this.bookmarks; // from the options passed in
+			this.bookmarkItems = cookie('bookmarkItems');
+			if (this.bookmarkItems === undefined) {
+				this.bookmarkItems = [];
+			} else {
+				this.bookmarkItems = json.parse(this.bookmarkItems);
+			}
             this.bookmarks = new Bookmarks({
                 map: this.map,
                 id: this.id + '_esri',
                 editable: this.editable,
                 bookmarks: lang.mixin(this.bookmarkItems, bookmarks)
-            }, this.domNode);
+            }, this.bookmarksNode);
+                        
+			this.connect(this.bookmarks, 'onEdit', 'setBookmarks');
+			this.connect(this.bookmarks, 'onRemove', 'setBookmarks');
+		},
+		setBookmarks: function () {
+			cookie('bookmarkItems', json.stringify(this.bookmarks.toJson()), {
+				expires: 365
+			});
+		},
+		_export: function () {
+			return json.stringify(this.bookmarks.toJson());
+		}
+	});
 
-            this.connect(this.bookmarks, 'onEdit', 'setBookmarks');
-            this.connect(this.bookmarks, 'onRemove', 'setBookmarks');
-        },
-        setBookmarks: function () {
-            cookie('bookmarkItems', json.stringify(this.bookmarks.toJson()), {
-                expires: 365
-            });
-        },
-        _export: function () {
-            return json.stringify(this.bookmarks.toJson());
-        }
-    });
 });

--- a/viewer/js/gis/dijit/Bookmarks.js
+++ b/viewer/js/gis/dijit/Bookmarks.js
@@ -1,13 +1,13 @@
 define([
 	'dojo/_base/declare',
 	'dijit/_WidgetBase',
-    'dijit/_TemplatedMixin',
-    'dijit/_WidgetsInTemplateMixin',
+        'dijit/_TemplatedMixin',
+        'dijit/_WidgetsInTemplateMixin',
    	'esri/dijit/Bookmarks',
-    'dojo/text!./Bookmarks/templates/Bookmarks.html',
+        'dojo/text!./Bookmarks/templates/Bookmarks.html',
 	'dojo/json',
 	'dojo/cookie',
-    'dojo/_base/lang',
+        'dojo/_base/lang',
 	'xstyle/css!./Bookmarks/css/Bookmarks.css'
 ], function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, Bookmarks, template, json, cookie, lang) {
 

--- a/viewer/js/gis/dijit/Bookmarks/templates/Bookmarks.html
+++ b/viewer/js/gis/dijit/Bookmarks/templates/Bookmarks.html
@@ -1,0 +1,3 @@
+<div class="gis_BookmarksDijit">
+   <div data-dojo-attach-point="bookmarksNode" ></div>
+</div>


### PR DESCRIPTION
<!-- Thank you for contributing to cmv! Contributions are welcome and are
absolutely necessary for the project to stay relevent and useful.
Please fill out the details to ensure others can understand the
changes you are proposing and how they will benefit the project. -->

# Description
<!-- Added template to Bookmarks Widget to correct issue with Javascript Api 3.22-->

# Use case

```javascript
// how the code can be used
```

# Checklist
<!-- please ensure your pull request passes the following check(s) -->

 - [ ] `grunt lint` produces no error messages
