### PR TITLE
Fix dynamic layer folders check-boxes initially not matching visibility

### DIFF
--- a/viewer/js/gis/dijit/LayerControl/controls/_DynamicFolder.js
+++ b/viewer/js/gis/dijit/LayerControl/controls/_DynamicFolder.js
@@ -69,6 +69,10 @@ define([
                 this._checkboxScaleRange();
                 this._handlers.push(this.control.layer.getMap().on('zoom-end', lang.hitch(this, '_checkboxScaleRange')));
             }
+            if (!this.control.controlOptions.ignoreDynamicGroupVisibility) {
+                var layerViz = (array.indexOf(this.control.layer.visibleLayers, this.sublayerInfo.id) !== -1);
+                this._setFolderCheckbox(layerViz, checkNode, true);
+            }
         },
 
         // add on event to expandClickNode


### PR DESCRIPTION
<!-- Thank you for contributing to cmv! Contributions are welcome and are
absolutely necessary for the project to stay relevent and useful.
Please fill out the details to ensure others can understand the
changes you are proposing and how they will benefit the project. -->

# Description
<!-- enter a description of the changes here -->

If a dynamic layer folder defaults to visible and `ignoreDynamicGroupVisibility` is set to `false` the checkbox in the layer control widget is initially unchecked, even though it's sublayers are visible.

# Use case

```javascript
// how the code can be used
```

# Checklist
<!-- please ensure your pull request passes the following check(s) -->

 - [x] `grunt lint` produces no error messages
