### PR TITLE
Fixes issue with `showAttachments` on dynamic layers

### DIFF
--- a/viewer/js/gis/dijit/Identify.js
+++ b/viewer/js/gis/dijit/Identify.js
@@ -155,10 +155,7 @@ define([
                     array.forEach(layer.layerInfos, lang.hitch(this, function (subLayerInfo) {
                         var subLayerId = subLayerInfo.id;
                         if ((typeof layerInfo.layerIds === 'undefined') || (array.indexOf(layerInfo.layerIds, subLayerId) >= 0)) {
-                            infoTemplate = this.getInfoTemplate(layer, subLayerId);
-                            if (infoTemplate && infoTemplate.info.showAttachments) {
-                                this.getFeatureLayerForDynamicSublayer(layer, subLayerId);
-                            }
+                            this.getFeatureLayerForDynamicSublayer(layer, subLayerId);
                         }
                     }));
                 }

--- a/viewer/js/gis/dijit/Identify.js
+++ b/viewer/js/gis/dijit/Identify.js
@@ -154,8 +154,11 @@ define([
                 } else if (layer.layerInfos) {
                     array.forEach(layer.layerInfos, lang.hitch(this, function (subLayerInfo) {
                         var subLayerId = subLayerInfo.id;
-                        if ((layerInfo.layerIds === null) || (array.indexOf(layerInfo.layerIds, subLayerId) >= 0)) {
-                            this.getFeatureLayerForDynamicSublayer(layer, subLayerId);
+                        if ((typeof layerInfo.layerIds === 'undefined') || (array.indexOf(layerInfo.layerIds, subLayerId) >= 0)) {
+                            infoTemplate = this.getInfoTemplate(layer, subLayerId);
+                            if (infoTemplate && infoTemplate.info.showAttachments) {
+                                this.getFeatureLayerForDynamicSublayer(layer, subLayerId);
+                            }
                         }
                     }));
                 }


### PR DESCRIPTION
Previously, this code was not executing when the layerIds array did not exist in the layer's configuration.

Also added a test for the `showAttachments` config property so that feature layers are added only for those layers with that property.